### PR TITLE
Change tests to TDD style, fix assertions performed in suite/describe blocks

### DIFF
--- a/test/api.js
+++ b/test/api.js
@@ -17,8 +17,8 @@
 var expect = require('expect.js');
 var ShiftParser = require('../');
 
-describe("API", function () {
-  it("should exist", function () {
+suite("API", function () {
+  test("should exist", function () {
     expect(typeof ShiftParser.default).be('function');
   });
 });

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -5,7 +5,7 @@ var ShiftParser = require('../');
 var parse = ShiftParser.default;
 
 exports.testParseFailure = function testParseFailure(source, message) {
-  it(source, function () {
+  test(source, function () {
     try {
       parse(source);
     } catch (e) {
@@ -17,9 +17,15 @@ exports.testParseFailure = function testParseFailure(source, message) {
 };
 
 exports.testEsprimaEquiv = function testEsprimaEquiv(source) {
-  it(source, function () {
+  test(source, function () {
     var tree = parse(source);
     var oracle = converters.toShift(esprima.parse(source));
     expect(tree).eql(oracle);
   });
 };
+
+exports.testParse = function testParse(program, fn) {
+  test(program, function () {
+    fn(parse(program));
+  });
+}

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,11 +1,12 @@
 var expect = require('expect.js');
 var esprima = require('esprima');
 var converters = require('shift-spidermonkey-converter');
-var ShiftParser = require('../');
-var parse = ShiftParser.default;
+var parse = require('../').default;
 
 exports.testParseFailure = function testParseFailure(source, message) {
+  var args = arguments.length;
   test(source, function () {
+    expect(args).to.be(testParseFailure.length);
     try {
       parse(source);
     } catch (e) {
@@ -17,15 +18,19 @@ exports.testParseFailure = function testParseFailure(source, message) {
 };
 
 exports.testEsprimaEquiv = function testEsprimaEquiv(source) {
+  var args = arguments.length;
   test(source, function () {
+    expect(args).to.be(testEsprimaEquiv.length);
     var tree = parse(source);
     var oracle = converters.toShift(esprima.parse(source));
     expect(tree).eql(oracle);
   });
 };
 
-exports.testParse = function testParse(program, fn) {
+exports.testParse = function testParse(program, accessor, expected) {
+  var args = arguments.length;
   test(program, function () {
-    fn(parse(program));
+    expect(args).to.be(testParse.length);
+    expect(accessor(parse(program))).to.eql(expected);
   });
 }

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -4,7 +4,7 @@ var converters = require('shift-spidermonkey-converter');
 var ShiftParser = require('../');
 var parse = ShiftParser.default;
 
-exports.assertParseFailure = function assertParseFailure(source, message) {
+exports.testParseFailure = function testParseFailure(source, message) {
   it(source, function () {
     try {
       parse(source);
@@ -16,7 +16,7 @@ exports.assertParseFailure = function assertParseFailure(source, message) {
   });
 };
 
-exports.assertEsprimaEquiv = function assertEsprimaEquiv(source) {
+exports.testEsprimaEquiv = function testEsprimaEquiv(source) {
   it(source, function () {
     var tree = parse(source);
     var oracle = converters.toShift(esprima.parse(source));

--- a/test/comments.js
+++ b/test/comments.js
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('./assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("Comments", function () {
-    assertEsprimaEquiv(" /**/");
-    assertEsprimaEquiv(" /****/");
-    assertEsprimaEquiv(" /**\n\r\r\n**/");
-    assertEsprimaEquiv(" //\n");
-    assertEsprimaEquiv("<!-- foo");
-    assertEsprimaEquiv("--> comment");
-    assertEsprimaEquiv("<!-- comment");
-    assertEsprimaEquiv(" \t --> comment");
-    assertEsprimaEquiv(" \t /* block comment */  --> comment");
-    assertEsprimaEquiv("/* block comment */--> comment");
+    testEsprimaEquiv(" /**/");
+    testEsprimaEquiv(" /****/");
+    testEsprimaEquiv(" /**\n\r\r\n**/");
+    testEsprimaEquiv(" //\n");
+    testEsprimaEquiv("<!-- foo");
+    testEsprimaEquiv("--> comment");
+    testEsprimaEquiv("<!-- comment");
+    testEsprimaEquiv(" \t --> comment");
+    testEsprimaEquiv(" \t /* block comment */  --> comment");
+    testEsprimaEquiv("/* block comment */--> comment");
   });
 });

--- a/test/comments.js
+++ b/test/comments.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("Comments", function () {
+suite("Parser", function () {
+  suite("Comments", function () {
     testEsprimaEquiv(" /**/");
     testEsprimaEquiv(" /****/");
     testEsprimaEquiv(" /**\n\r\r\n**/");

--- a/test/directives/use-strict-directive.js
+++ b/test/directives/use-strict-directive.js
@@ -28,8 +28,8 @@ function directives(program) {
   return program.body.directives;
 }
 
-describe("Parser", function () {
-  describe("directive", function () {
+suite("Parser", function () {
+  suite("directive", function () {
     expect(directives(parse("\"Hello\""))).to.be.eql([new Shift.UnknownDirective("Hello")]);
     expect(directives(parse("\"\\n\\r\\t\\v\\b\\f\\\\\\'\\\"\\0\""))).to.be.eql([new Shift.UnknownDirective("\n\r\t\v\b\f\\\'\"\0")]);
     expect(directives(parse("\"\\u0061\""))).to.be.eql([new Shift.UnknownDirective("a")]);
@@ -51,7 +51,7 @@ describe("Parser", function () {
     expect(directives(parse("\"Hello\\1World\""))).to.be.eql([new Shift.UnknownDirective("Hello\1World")]);
   });
 
-  describe("use strict directive", function () {
+  suite("use strict directive", function () {
     testParseFailure("(function () { 'use strict'; with (i); })", "Strict mode code may not include a with statement");
     expect(expr(parse("(function () { 'use\\x20strict'; with (i); })"))).to.be.eql(
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([new Shift.UnknownDirective("use strict")], [

--- a/test/directives/use-strict-directive.js
+++ b/test/directives/use-strict-directive.js
@@ -22,7 +22,7 @@ var Shift = require("shift-ast");
 var expr = require("../helpers").expr;
 var stmt = require("../helpers").stmt;
 
-var assertParseFailure = require('../assertions').assertParseFailure;
+var testParseFailure = require('../assertions').testParseFailure;
 
 function directives(program) {
   return program.body.directives;
@@ -52,7 +52,7 @@ describe("Parser", function () {
   });
 
   describe("use strict directive", function () {
-    assertParseFailure("(function () { 'use strict'; with (i); })", "Strict mode code may not include a with statement");
+    testParseFailure("(function () { 'use strict'; with (i); })", "Strict mode code may not include a with statement");
     expect(expr(parse("(function () { 'use\\x20strict'; with (i); })"))).to.be.eql(
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([new Shift.UnknownDirective("use strict")], [
         new Shift.WithStatement(new Shift.IdentifierExpression(new Shift.Identifier("i")), new Shift.EmptyStatement),

--- a/test/directives/use-strict-directive.js
+++ b/test/directives/use-strict-directive.js
@@ -14,67 +14,66 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
 var stmt = require("../helpers").stmt;
 
 var testParseFailure = require('../assertions').testParseFailure;
+var testParse = require('../assertions').testParse;
 
 function directives(program) {
   return program.body.directives;
 }
 
 suite("Parser", function () {
-  suite("directive", function () {
-    expect(directives(parse("\"Hello\""))).to.be.eql([new Shift.UnknownDirective("Hello")]);
-    expect(directives(parse("\"\\n\\r\\t\\v\\b\\f\\\\\\'\\\"\\0\""))).to.be.eql([new Shift.UnknownDirective("\n\r\t\v\b\f\\\'\"\0")]);
-    expect(directives(parse("\"\\u0061\""))).to.be.eql([new Shift.UnknownDirective("a")]);
-    expect(directives(parse("\"\\x61\""))).to.be.eql([new Shift.UnknownDirective("a")]);
-    expect(directives(parse("\"\\u00\""))).to.be.eql([new Shift.UnknownDirective("u00")]);
-    expect(directives(parse("\"\\xt\""))).to.be.eql([new Shift.UnknownDirective("xt")]);
-    expect(directives(parse("\"Hello\\nworld\""))).to.be.eql([new Shift.UnknownDirective("Hello\nworld")]);
-    expect(directives(parse("\"Hello\\\nworld\""))).to.be.eql([new Shift.UnknownDirective("Helloworld")]);
-    expect(directives(parse("\"Hello\\02World\""))).to.be.eql([new Shift.UnknownDirective("Hello\x02World")]);
-    expect(directives(parse("\"Hello\\012World\""))).to.be.eql([new Shift.UnknownDirective("Hello\nWorld")]);
-    expect(directives(parse("\"Hello\\122World\""))).to.be.eql([new Shift.UnknownDirective("HelloRWorld")]);
-    expect(directives(parse("\"Hello\\0122World\""))).to.be.eql([new Shift.UnknownDirective("Hello\n2World")]);
-    expect(directives(parse("\"Hello\\312World\""))).to.be.eql([new Shift.UnknownDirective("Hello\xCAWorld")]);
-    expect(directives(parse("\"Hello\\412World\""))).to.be.eql([new Shift.UnknownDirective("Hello!2World")]);
-    expect(directives(parse("\"Hello\\812World\""))).to.be.eql([new Shift.UnknownDirective("Hello812World")]);
-    expect(directives(parse("\"Hello\\712World\""))).to.be.eql([new Shift.UnknownDirective("Hello92World")]);
-    expect(directives(parse("\"Hello\\0World\""))).to.be.eql([new Shift.UnknownDirective("Hello\0World")]);
-    expect(directives(parse("\"Hello\\\r\nworld\""))).to.be.eql([new Shift.UnknownDirective("Helloworld")]);
-    expect(directives(parse("\"Hello\\1World\""))).to.be.eql([new Shift.UnknownDirective("Hello\1World")]);
-  });
+  suite("use strict", function () {
 
-  suite("use strict directive", function () {
+    testParse("\"Hello\"", directives, [new Shift.UnknownDirective("Hello")]);
+
+    testParse("\"\\n\\r\\t\\v\\b\\f\\\\\\'\\\"\\0\"", directives, [new Shift.UnknownDirective("\n\r\t\v\b\f\\\'\"\0")]);
+    testParse("\"\\u0061\"", directives, [new Shift.UnknownDirective("a")]);
+    testParse("\"\\x61\"", directives, [new Shift.UnknownDirective("a")]);
+    testParse("\"\\u00\"", directives, [new Shift.UnknownDirective("u00")]);
+    testParse("\"\\xt\"", directives, [new Shift.UnknownDirective("xt")]);
+    testParse("\"Hello\\nworld\"", directives, [new Shift.UnknownDirective("Hello\nworld")]);
+    testParse("\"Hello\\\nworld\"", directives, [new Shift.UnknownDirective("Helloworld")]);
+    testParse("\"Hello\\02World\"", directives, [new Shift.UnknownDirective("Hello\x02World")]);
+    testParse("\"Hello\\012World\"", directives, [new Shift.UnknownDirective("Hello\nWorld")]);
+    testParse("\"Hello\\122World\"", directives, [new Shift.UnknownDirective("HelloRWorld")]);
+    testParse("\"Hello\\0122World\"", directives, [new Shift.UnknownDirective("Hello\n2World")]);
+    testParse("\"Hello\\312World\"", directives, [new Shift.UnknownDirective("Hello\xCAWorld")]);
+    testParse("\"Hello\\412World\"", directives, [new Shift.UnknownDirective("Hello!2World")]);
+    testParse("\"Hello\\812World\"", directives, [new Shift.UnknownDirective("Hello812World")]);
+    testParse("\"Hello\\712World\"", directives, [new Shift.UnknownDirective("Hello92World")]);
+    testParse("\"Hello\\0World\"", directives, [new Shift.UnknownDirective("Hello\0World")]);
+    testParse("\"Hello\\\r\nworld\"", directives, [new Shift.UnknownDirective("Helloworld")]);
+    testParse("\"Hello\\1World\"", directives, [new Shift.UnknownDirective("Hello\1World")]);
+
     testParseFailure("(function () { 'use strict'; with (i); })", "Strict mode code may not include a with statement");
-    expect(expr(parse("(function () { 'use\\x20strict'; with (i); })"))).to.be.eql(
+
+    testParse("(function () { 'use\\x20strict'; with (i); })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([new Shift.UnknownDirective("use strict")], [
         new Shift.WithStatement(new Shift.IdentifierExpression(new Shift.Identifier("i")), new Shift.EmptyStatement),
       ]))
     );
-    expect(expr(parse("(function () { 'use\\nstrict'; with (i); })"))).to.be.eql(
+    testParse("(function () { 'use\\nstrict'; with (i); })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([new Shift.UnknownDirective("use\nstrict")], [
         new Shift.WithStatement(new Shift.IdentifierExpression(new Shift.Identifier("i")), new Shift.EmptyStatement),
       ]))
     );
 
-    expect(stmt(parse("function a() {'use strict';return 0;};"))).to.be.eql(
+    testParse("function a() {'use strict';return 0;};", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("a"), [], new Shift.FunctionBody([new Shift.UseStrictDirective], [
         new Shift.ReturnStatement(new Shift.LiteralNumericExpression(0)),
       ]))
     );
-    expect(expr(parse("(function() {'use strict';return 0;});"))).to.be.eql(
+    testParse("(function() {'use strict';return 0;});", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([new Shift.UseStrictDirective()], [
         new Shift.ReturnStatement(new Shift.LiteralNumericExpression(0)),
       ]))
     );
-    expect(expr(parse("(function a() {'use strict';return 0;});"))).to.be.eql(
+    testParse("(function a() {'use strict';return 0;});", expr,
       new Shift.FunctionExpression(new Shift.Identifier("a"), [], new Shift.FunctionBody([new Shift.UseStrictDirective], [
         new Shift.ReturnStatement(new Shift.LiteralNumericExpression(0)),
       ]))

--- a/test/failure.js
+++ b/test/failure.js
@@ -14,348 +14,348 @@
  * limitations under the License.
  */
 
-var assertParseFailure = require('./assertions').assertParseFailure;
+var testParseFailure = require('./assertions').testParseFailure;
 
 describe("Parser", function () {
 
   describe("error handling", function () {
-    assertParseFailure("/*", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\r", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\r\n", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\u2028", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\u2029", "Unexpected token ILLEGAL");
-    assertParseFailure("/**", "Unexpected token ILLEGAL");
-    assertParseFailure("\\", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u", "Unexpected token ILLEGAL");
-    assertParseFailure("\\x", "Unexpected token ILLEGAL");
-    assertParseFailure("\\o", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u1", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u12", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u113", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\uz   ", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u1z  ", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u11z ", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u111z", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\x", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\o", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u1", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u12", "Unexpected token ILLEGAL");
-    assertParseFailure("a\\u113", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\03", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\x", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\x1", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\x1   ", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\x12  ", "Unexpected token ILLEGAL");
-    assertParseFailure("'\n", "Unexpected token ILLEGAL");
-    assertParseFailure("'\\", "Unexpected token ILLEGAL");
-    assertParseFailure("＊", "Unexpected token ILLEGAL");
-    assertParseFailure("1.a", "Unexpected token ILLEGAL");
-    assertParseFailure("1.e", "Unexpected token ILLEGAL");
-    assertParseFailure("1.e+", "Unexpected token ILLEGAL");
-    assertParseFailure("1.e+z", "Unexpected token ILLEGAL");
-    assertParseFailure("/\\\n42", "Invalid regular expression: missing /");
-    assertParseFailure("0x", "Unexpected token ILLEGAL");
-    assertParseFailure("0xz", "Unexpected token ILLEGAL");
-    assertParseFailure("0x1z", "Unexpected token ILLEGAL");
-    assertParseFailure("0a", "Unexpected token ILLEGAL");
-    assertParseFailure("08a", "Unexpected token ILLEGAL");
-    assertParseFailure("\u0008", "Unexpected token ILLEGAL");
+    testParseFailure("/*", "Unexpected token ILLEGAL");
+    testParseFailure("/*\r", "Unexpected token ILLEGAL");
+    testParseFailure("/*\r\n", "Unexpected token ILLEGAL");
+    testParseFailure("/*\u2028", "Unexpected token ILLEGAL");
+    testParseFailure("/*\u2029", "Unexpected token ILLEGAL");
+    testParseFailure("/**", "Unexpected token ILLEGAL");
+    testParseFailure("\\", "Unexpected token ILLEGAL");
+    testParseFailure("\\u", "Unexpected token ILLEGAL");
+    testParseFailure("\\x", "Unexpected token ILLEGAL");
+    testParseFailure("\\o", "Unexpected token ILLEGAL");
+    testParseFailure("\\u1", "Unexpected token ILLEGAL");
+    testParseFailure("\\u12", "Unexpected token ILLEGAL");
+    testParseFailure("\\u113", "Unexpected token ILLEGAL");
+    testParseFailure("a\\uz   ", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u1z  ", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u11z ", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u111z", "Unexpected token ILLEGAL");
+    testParseFailure("a\\", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u", "Unexpected token ILLEGAL");
+    testParseFailure("a\\x", "Unexpected token ILLEGAL");
+    testParseFailure("a\\o", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u1", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u12", "Unexpected token ILLEGAL");
+    testParseFailure("a\\u113", "Unexpected token ILLEGAL");
+    testParseFailure("'\\03", "Unexpected token ILLEGAL");
+    testParseFailure("'\\x", "Unexpected token ILLEGAL");
+    testParseFailure("'\\x1", "Unexpected token ILLEGAL");
+    testParseFailure("'\\x1   ", "Unexpected token ILLEGAL");
+    testParseFailure("'\\x12  ", "Unexpected token ILLEGAL");
+    testParseFailure("'\n", "Unexpected token ILLEGAL");
+    testParseFailure("'\\", "Unexpected token ILLEGAL");
+    testParseFailure("＊", "Unexpected token ILLEGAL");
+    testParseFailure("1.a", "Unexpected token ILLEGAL");
+    testParseFailure("1.e", "Unexpected token ILLEGAL");
+    testParseFailure("1.e+", "Unexpected token ILLEGAL");
+    testParseFailure("1.e+z", "Unexpected token ILLEGAL");
+    testParseFailure("/\\\n42", "Invalid regular expression: missing /");
+    testParseFailure("0x", "Unexpected token ILLEGAL");
+    testParseFailure("0xz", "Unexpected token ILLEGAL");
+    testParseFailure("0x1z", "Unexpected token ILLEGAL");
+    testParseFailure("0a", "Unexpected token ILLEGAL");
+    testParseFailure("08a", "Unexpected token ILLEGAL");
+    testParseFailure("\u0008", "Unexpected token ILLEGAL");
 
-    assertParseFailure("{", "Unexpected end of input");
-    assertParseFailure("}", "Unexpected token }");
-    assertParseFailure("3ea", "Unexpected token ILLEGAL");
-    assertParseFailure("3in []", "Unexpected token ILLEGAL");
-    assertParseFailure("3e", "Unexpected token ILLEGAL");
-    assertParseFailure("3e+", "Unexpected token ILLEGAL");
-    assertParseFailure("3e-", "Unexpected token ILLEGAL");
-    assertParseFailure("3x", "Unexpected token ILLEGAL");
-    assertParseFailure("3x0", "Unexpected token ILLEGAL");
-    assertParseFailure("0x", "Unexpected token ILLEGAL");
-    assertParseFailure("09", "Unexpected token ILLEGAL");
-    assertParseFailure("018", "Unexpected token ILLEGAL");
-    assertParseFailure("01a", "Unexpected token ILLEGAL");
-    assertParseFailure("3in[]", "Unexpected token ILLEGAL");
-    assertParseFailure("0x3in[]", "Unexpected token ILLEGAL");
-    assertParseFailure("\"Hello\nWorld\"", "Unexpected token ILLEGAL");
-    assertParseFailure("x\\", "Unexpected token ILLEGAL");
-    assertParseFailure("x\\u005c", "Unexpected token ILLEGAL");
-    assertParseFailure("x\\u002a", "Unexpected token ILLEGAL");
-    assertParseFailure("var x = /(s/g", "Invalid regular expression");
-    assertParseFailure("a\\u", "Unexpected token ILLEGAL");
-    assertParseFailure("\\ua", "Unexpected token ILLEGAL");
-    assertParseFailure("/", "Invalid regular expression: missing /");
-    assertParseFailure("/test", "Invalid regular expression: missing /");
-    assertParseFailure("/test\n/", "Invalid regular expression: missing /");
-    assertParseFailure("var x = /[a-z]/\\ux", "Invalid regular expression");
-    assertParseFailure("var x = /[a-z\n]/\\ux", "Invalid regular expression: missing /");
-    assertParseFailure("var x = /[a-z]/\\\\ux", "Invalid regular expression");
-    assertParseFailure("var x = /[P QR]/\\\\u0067", "Invalid regular expression");
+    testParseFailure("{", "Unexpected end of input");
+    testParseFailure("}", "Unexpected token }");
+    testParseFailure("3ea", "Unexpected token ILLEGAL");
+    testParseFailure("3in []", "Unexpected token ILLEGAL");
+    testParseFailure("3e", "Unexpected token ILLEGAL");
+    testParseFailure("3e+", "Unexpected token ILLEGAL");
+    testParseFailure("3e-", "Unexpected token ILLEGAL");
+    testParseFailure("3x", "Unexpected token ILLEGAL");
+    testParseFailure("3x0", "Unexpected token ILLEGAL");
+    testParseFailure("0x", "Unexpected token ILLEGAL");
+    testParseFailure("09", "Unexpected token ILLEGAL");
+    testParseFailure("018", "Unexpected token ILLEGAL");
+    testParseFailure("01a", "Unexpected token ILLEGAL");
+    testParseFailure("3in[]", "Unexpected token ILLEGAL");
+    testParseFailure("0x3in[]", "Unexpected token ILLEGAL");
+    testParseFailure("\"Hello\nWorld\"", "Unexpected token ILLEGAL");
+    testParseFailure("x\\", "Unexpected token ILLEGAL");
+    testParseFailure("x\\u005c", "Unexpected token ILLEGAL");
+    testParseFailure("x\\u002a", "Unexpected token ILLEGAL");
+    testParseFailure("var x = /(s/g", "Invalid regular expression");
+    testParseFailure("a\\u", "Unexpected token ILLEGAL");
+    testParseFailure("\\ua", "Unexpected token ILLEGAL");
+    testParseFailure("/", "Invalid regular expression: missing /");
+    testParseFailure("/test", "Invalid regular expression: missing /");
+    testParseFailure("/test\n/", "Invalid regular expression: missing /");
+    testParseFailure("var x = /[a-z]/\\ux", "Invalid regular expression");
+    testParseFailure("var x = /[a-z\n]/\\ux", "Invalid regular expression: missing /");
+    testParseFailure("var x = /[a-z]/\\\\ux", "Invalid regular expression");
+    testParseFailure("var x = /[P QR]/\\\\u0067", "Invalid regular expression");
 
-    // assertParseFailure("3 = 4", "Invalid left-hand side in assignment");
-    // assertParseFailure("func() = 4", "Invalid left-hand side in assignment");
-    // assertParseFailure("(1 + 1) = 10", "Invalid left-hand side in assignment");
+    // testParseFailure("3 = 4", "Invalid left-hand side in assignment");
+    // testParseFailure("func() = 4", "Invalid left-hand side in assignment");
+    // testParseFailure("(1 + 1) = 10", "Invalid left-hand side in assignment");
 
-    // assertParseFailure("1++", "Invalid left-hand side in assignment");
-    // assertParseFailure("1--", "Invalid left-hand side in assignment");
-    // assertParseFailure("++1", "Invalid left-hand side in assignment");
-    // assertParseFailure("--1", "Invalid left-hand side in assignment");
-    assertParseFailure("--(1+1)", "Invalid left-hand side in assignment");
-    assertParseFailure("(1+1)--", "Invalid left-hand side in assignment");
+    // testParseFailure("1++", "Invalid left-hand side in assignment");
+    // testParseFailure("1--", "Invalid left-hand side in assignment");
+    // testParseFailure("++1", "Invalid left-hand side in assignment");
+    // testParseFailure("--1", "Invalid left-hand side in assignment");
+    testParseFailure("--(1+1)", "Invalid left-hand side in assignment");
+    testParseFailure("(1+1)--", "Invalid left-hand side in assignment");
 
-    assertParseFailure("for((1 + 1) in list) process(x);", "Invalid left-hand side in for-in");
-    assertParseFailure("[", "Unexpected end of input");
-    assertParseFailure("[,", "Unexpected end of input");
-    assertParseFailure("1 + {", "Unexpected end of input");
-    assertParseFailure("1 + { t:t ", "Unexpected end of input");
-    assertParseFailure("1 + { t:t,", "Unexpected end of input");
-    assertParseFailure("var x = /\n/", "Invalid regular expression: missing /");
-    assertParseFailure("var x = \"\n", "Unexpected token ILLEGAL");
-    assertParseFailure("var if = 42", "Unexpected token if");
-    assertParseFailure("i #= 42", "Unexpected token ILLEGAL");
-    assertParseFailure("1 + (", "Unexpected end of input");
-    assertParseFailure("\n\n\n{", "Unexpected end of input");
-    assertParseFailure("\n/* Some multiline\ncomment */\n)", "Unexpected token )");
-    assertParseFailure("{ set 1 }", "Unexpected number");
-    assertParseFailure("{ get 2 }", "Unexpected number");
-    assertParseFailure("({ set: s(if) { } })", "Unexpected token if");
-    assertParseFailure("({ set s(.) { } })", "Unexpected token .");
-    assertParseFailure("({ set s() { } })", "Unexpected token )");
-    assertParseFailure("({ set: s() { } })", "Unexpected token {");
-    assertParseFailure("({ set: s(a, b) { } })", "Unexpected token {");
-    assertParseFailure("({ get: g(d) { } })", "Unexpected token {");
-    assertParseFailure("({ get i() { }, i: 42 })",
+    testParseFailure("for((1 + 1) in list) process(x);", "Invalid left-hand side in for-in");
+    testParseFailure("[", "Unexpected end of input");
+    testParseFailure("[,", "Unexpected end of input");
+    testParseFailure("1 + {", "Unexpected end of input");
+    testParseFailure("1 + { t:t ", "Unexpected end of input");
+    testParseFailure("1 + { t:t,", "Unexpected end of input");
+    testParseFailure("var x = /\n/", "Invalid regular expression: missing /");
+    testParseFailure("var x = \"\n", "Unexpected token ILLEGAL");
+    testParseFailure("var if = 42", "Unexpected token if");
+    testParseFailure("i #= 42", "Unexpected token ILLEGAL");
+    testParseFailure("1 + (", "Unexpected end of input");
+    testParseFailure("\n\n\n{", "Unexpected end of input");
+    testParseFailure("\n/* Some multiline\ncomment */\n)", "Unexpected token )");
+    testParseFailure("{ set 1 }", "Unexpected number");
+    testParseFailure("{ get 2 }", "Unexpected number");
+    testParseFailure("({ set: s(if) { } })", "Unexpected token if");
+    testParseFailure("({ set s(.) { } })", "Unexpected token .");
+    testParseFailure("({ set s() { } })", "Unexpected token )");
+    testParseFailure("({ set: s() { } })", "Unexpected token {");
+    testParseFailure("({ set: s(a, b) { } })", "Unexpected token {");
+    testParseFailure("({ get: g(d) { } })", "Unexpected token {");
+    testParseFailure("({ get i() { }, i: 42 })",
         "Object literal may not have data and accessor property with the same name");
-    assertParseFailure("({ i: 42, get i() { } })",
+    testParseFailure("({ i: 42, get i() { } })",
         "Object literal may not have data and accessor property with the same name");
-    assertParseFailure("({ set i(x) { }, i: 42 })",
+    testParseFailure("({ set i(x) { }, i: 42 })",
         "Object literal may not have data and accessor property with the same name");
-    assertParseFailure("({ i: 42, set i(x) { } })",
+    testParseFailure("({ i: 42, set i(x) { } })",
         "Object literal may not have data and accessor property with the same name");
-    assertParseFailure("({ get i() { }, get i() { } })",
+    testParseFailure("({ get i() { }, get i() { } })",
         "Object literal may not have multiple get/set accessors with the same name");
-    assertParseFailure("({ set i(x) { }, set i(x) { } })",
+    testParseFailure("({ set i(x) { }, set i(x) { } })",
         "Object literal may not have multiple get/set accessors with the same name");
     // TODO: ES6:
-    // assertParseFailure("((a)) => 42", "Unexpected token =>");
-    // assertParseFailure("(a, (b)) => 42", "Unexpected token =>");
-    // assertParseFailure("\"use strict\"; (eval = 10) => 42", "Assignment to eval or arguments is not allowed in strict mode");
+    // testParseFailure("((a)) => 42", "Unexpected token =>");
+    // testParseFailure("(a, (b)) => 42", "Unexpected token =>");
+    // testParseFailure("\"use strict\"; (eval = 10) => 42", "Assignment to eval or arguments is not allowed in strict mode");
     // strict mode, using eval when IsSimpleParameterList is true
-    // assertParseFailure("\"use strict\"; eval => 42", "Parameter name eval or arguments is not allowed in strict mode");
+    // testParseFailure("\"use strict\"; eval => 42", "Parameter name eval or arguments is not allowed in strict mode");
     // strict mode, using arguments when IsSimpleParameterList is true
-    // assertParseFailure("\"use strict\"; arguments => 42", "Parameter name eval or arguments is not allowed in strict mode");
+    // testParseFailure("\"use strict\"; arguments => 42", "Parameter name eval or arguments is not allowed in strict mode");
     // strict mode, using eval when IsSimpleParameterList is true
-    // assertParseFailure("\"use strict\"; (eval, a) => 42", "Parameter name eval or arguments is not allowed in strict mode");
+    // testParseFailure("\"use strict\"; (eval, a) => 42", "Parameter name eval or arguments is not allowed in strict mode");
     // strict mode, using arguments when IsSimpleParameterList is true
-    // assertParseFailure("\"use strict\"; (arguments, a) => 42", "Parameter name eval or arguments is not allowed in strict mode");
-    // assertParseFailure("(a, a) => 42", "Strict mode function may not have duplicate parameter names");
-    // assertParseFailure("\"use strict\"; (a, a) => 42", "Strict mode function may not have duplicate parameter names");
-    // assertParseFailure("\"use strict\"; (a) => 00", "Octal literals are not allowed in strict mode.");
-    // assertParseFailure("() <= 42", "Unexpected token <=");
-    // assertParseFailure("() ? 42", "Unexpected token ?");
-    // assertParseFailure("() + 42", "Unexpected token +");
-    // assertParseFailure("(10) => 00", "Unexpected token =>");
-    // assertParseFailure("(10, 20) => 00", "Unexpected token =>");
-    // assertParseFailure("\"use strict\"; (eval) => 42", "Parameter name eval or arguments is not allowed in strict mode");
-    // assertParseFailure("(eval) => { \"use strict\"; 42 }", "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function t(if) { }", "Unexpected token if");
-    assertParseFailure("function t(true) { }", "Unexpected token true");
-    assertParseFailure("function t(false) { }", "Unexpected token false");
-    assertParseFailure("function t(null) { }", "Unexpected token null");
-    assertParseFailure("function null() { }", "Unexpected token null");
-    assertParseFailure("function true() { }", "Unexpected token true");
-    assertParseFailure("function false() { }", "Unexpected token false");
-    assertParseFailure("function if() { }", "Unexpected token if");
-    assertParseFailure("a b;", "Unexpected identifier");
-    assertParseFailure("if.a;", "Unexpected token .");
-    assertParseFailure("a if;", "Unexpected token if");
-    assertParseFailure("a class;", "Unexpected reserved word");
-    assertParseFailure("break\n", "Illegal break statement");
-    assertParseFailure("break 1;", "Unexpected number");
-    assertParseFailure("continue\n", "Illegal continue statement");
-    assertParseFailure("continue 2;", "Unexpected number");
-    assertParseFailure("throw", "Unexpected end of input");
-    assertParseFailure("throw;", "Unexpected token ;");
-    assertParseFailure("throw\n", "Illegal newline after throw");
-    assertParseFailure("for (var i, i2 in {});", "Unexpected token in");
-    assertParseFailure("for ((i in {}));", "Unexpected token )");
-    assertParseFailure("for (i + 1 in {});", "Invalid left-hand side in for-in");
-    assertParseFailure("for (+i in {});", "Invalid left-hand side in for-in");
-    assertParseFailure("if(false)", "Unexpected end of input");
-    assertParseFailure("if(false) doThis(); else", "Unexpected end of input");
-    assertParseFailure("do", "Unexpected end of input");
-    assertParseFailure("while(false)", "Unexpected end of input");
-    assertParseFailure("for(;;)", "Unexpected end of input");
-    assertParseFailure("with(x)", "Unexpected end of input");
-    assertParseFailure("try { }", "Missing catch or finally after try");
-    assertParseFailure("try {} catch (42) {} ", "Unexpected number");
-    assertParseFailure("try {} catch (answer()) {} ", "Unexpected token (");
-    assertParseFailure("try {} catch (-x) {} ", "Unexpected token -");
-    assertParseFailure("\u203F = 10", "Unexpected token ILLEGAL");
-    assertParseFailure("const x = 12, y;", "Unexpected token ;");
-    assertParseFailure("const x, y = 12;", "Unexpected token ,");
-    assertParseFailure("const x;", "Unexpected token ;");
-    // TODO : assertParseFailure("if(true) let a = 1;", "Unexpected token let");
-    // TODO : assertParseFailure("if(true) const a = 1;", "Unexpected token const");
-    assertParseFailure("switch (c) { default: default: }", "More than one default clause in switch statement");
-    assertParseFailure("new X().\"s\"", "Unexpected string");
-    assertParseFailure("/*", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\n\n\n", "Unexpected token ILLEGAL");
-    assertParseFailure("/**", "Unexpected token ILLEGAL");
-    assertParseFailure("/*\n\n*", "Unexpected token ILLEGAL");
-    assertParseFailure("/*hello", "Unexpected token ILLEGAL");
-    assertParseFailure("/*hello  *", "Unexpected token ILLEGAL");
-    assertParseFailure("\n]", "Unexpected token ]");
-    assertParseFailure("\r]", "Unexpected token ]");
-    assertParseFailure("\r\n]", "Unexpected token ]");
-    assertParseFailure("\n\r]", "Unexpected token ]");
-    assertParseFailure("//\r\n]", "Unexpected token ]");
-    assertParseFailure("//\n\r]", "Unexpected token ]");
-    assertParseFailure("/a\\\n/", "Invalid regular expression: missing /");
-    assertParseFailure("//\r \n]", "Unexpected token ]");
-    assertParseFailure("/*\r\n*/]", "Unexpected token ]");
-    assertParseFailure("/*\n\r*/]", "Unexpected token ]");
-    assertParseFailure("/*\r \n*/]", "Unexpected token ]");
-    assertParseFailure("\\\\", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u005c", "Unexpected token ILLEGAL");
-    assertParseFailure("\\x", "Unexpected token ILLEGAL");
-    assertParseFailure("\\u0000", "Unexpected token ILLEGAL");
-    assertParseFailure("\u200C = []", "Unexpected token ILLEGAL");
-    assertParseFailure("\u200D = []", "Unexpected token ILLEGAL");
-    assertParseFailure("\"\\", "Unexpected token ILLEGAL");
-    assertParseFailure("\"\\u", "Unexpected token ILLEGAL");
-    assertParseFailure("try { } catch() {}", "Unexpected token )");
-    assertParseFailure("return", "Illegal return statement");
-    assertParseFailure("break", "Illegal break statement");
-    assertParseFailure("continue", "Illegal continue statement");
-    assertParseFailure("switch (x) { default: continue; }", "Illegal continue statement");
-    assertParseFailure("do { x } *", "Unexpected token *");
-    assertParseFailure("while (true) { break x; }", "Undefined label \'x\'");
-    assertParseFailure("while (true) { continue x; }", "Undefined label \'x\'");
-    assertParseFailure("x: while (true) { (function () { break x; }); }", "Undefined label \'x\'");
-    assertParseFailure("x: while (true) { (function () { continue x; }); }", "Undefined label \'x\'");
-    assertParseFailure("x: while (true) { (function () { break; }); }", "Illegal break statement");
-    assertParseFailure("x: while (true) { (function () { continue; }); }", "Illegal continue statement");
-    assertParseFailure("x: while (true) { x: while (true) { } }", "Label \'x\' has already been declared");
-    assertParseFailure("(function () { \'use strict\'; delete i; }())", "Delete of an unqualified identifier in strict mode.");
-    assertParseFailure("(function () { \'use strict\'; with (i); }())", "Strict mode code may not include a with statement");
-    assertParseFailure("function hello() {\'use strict\'; ({ i: 42, i: 42 }) }",
+    // testParseFailure("\"use strict\"; (arguments, a) => 42", "Parameter name eval or arguments is not allowed in strict mode");
+    // testParseFailure("(a, a) => 42", "Strict mode function may not have duplicate parameter names");
+    // testParseFailure("\"use strict\"; (a, a) => 42", "Strict mode function may not have duplicate parameter names");
+    // testParseFailure("\"use strict\"; (a) => 00", "Octal literals are not allowed in strict mode.");
+    // testParseFailure("() <= 42", "Unexpected token <=");
+    // testParseFailure("() ? 42", "Unexpected token ?");
+    // testParseFailure("() + 42", "Unexpected token +");
+    // testParseFailure("(10) => 00", "Unexpected token =>");
+    // testParseFailure("(10, 20) => 00", "Unexpected token =>");
+    // testParseFailure("\"use strict\"; (eval) => 42", "Parameter name eval or arguments is not allowed in strict mode");
+    // testParseFailure("(eval) => { \"use strict\"; 42 }", "Parameter name eval or arguments is not allowed in strict mode");
+    testParseFailure("function t(if) { }", "Unexpected token if");
+    testParseFailure("function t(true) { }", "Unexpected token true");
+    testParseFailure("function t(false) { }", "Unexpected token false");
+    testParseFailure("function t(null) { }", "Unexpected token null");
+    testParseFailure("function null() { }", "Unexpected token null");
+    testParseFailure("function true() { }", "Unexpected token true");
+    testParseFailure("function false() { }", "Unexpected token false");
+    testParseFailure("function if() { }", "Unexpected token if");
+    testParseFailure("a b;", "Unexpected identifier");
+    testParseFailure("if.a;", "Unexpected token .");
+    testParseFailure("a if;", "Unexpected token if");
+    testParseFailure("a class;", "Unexpected reserved word");
+    testParseFailure("break\n", "Illegal break statement");
+    testParseFailure("break 1;", "Unexpected number");
+    testParseFailure("continue\n", "Illegal continue statement");
+    testParseFailure("continue 2;", "Unexpected number");
+    testParseFailure("throw", "Unexpected end of input");
+    testParseFailure("throw;", "Unexpected token ;");
+    testParseFailure("throw\n", "Illegal newline after throw");
+    testParseFailure("for (var i, i2 in {});", "Unexpected token in");
+    testParseFailure("for ((i in {}));", "Unexpected token )");
+    testParseFailure("for (i + 1 in {});", "Invalid left-hand side in for-in");
+    testParseFailure("for (+i in {});", "Invalid left-hand side in for-in");
+    testParseFailure("if(false)", "Unexpected end of input");
+    testParseFailure("if(false) doThis(); else", "Unexpected end of input");
+    testParseFailure("do", "Unexpected end of input");
+    testParseFailure("while(false)", "Unexpected end of input");
+    testParseFailure("for(;;)", "Unexpected end of input");
+    testParseFailure("with(x)", "Unexpected end of input");
+    testParseFailure("try { }", "Missing catch or finally after try");
+    testParseFailure("try {} catch (42) {} ", "Unexpected number");
+    testParseFailure("try {} catch (answer()) {} ", "Unexpected token (");
+    testParseFailure("try {} catch (-x) {} ", "Unexpected token -");
+    testParseFailure("\u203F = 10", "Unexpected token ILLEGAL");
+    testParseFailure("const x = 12, y;", "Unexpected token ;");
+    testParseFailure("const x, y = 12;", "Unexpected token ,");
+    testParseFailure("const x;", "Unexpected token ;");
+    // TODO : testParseFailure("if(true) let a = 1;", "Unexpected token let");
+    // TODO : testParseFailure("if(true) const a = 1;", "Unexpected token const");
+    testParseFailure("switch (c) { default: default: }", "More than one default clause in switch statement");
+    testParseFailure("new X().\"s\"", "Unexpected string");
+    testParseFailure("/*", "Unexpected token ILLEGAL");
+    testParseFailure("/*\n\n\n", "Unexpected token ILLEGAL");
+    testParseFailure("/**", "Unexpected token ILLEGAL");
+    testParseFailure("/*\n\n*", "Unexpected token ILLEGAL");
+    testParseFailure("/*hello", "Unexpected token ILLEGAL");
+    testParseFailure("/*hello  *", "Unexpected token ILLEGAL");
+    testParseFailure("\n]", "Unexpected token ]");
+    testParseFailure("\r]", "Unexpected token ]");
+    testParseFailure("\r\n]", "Unexpected token ]");
+    testParseFailure("\n\r]", "Unexpected token ]");
+    testParseFailure("//\r\n]", "Unexpected token ]");
+    testParseFailure("//\n\r]", "Unexpected token ]");
+    testParseFailure("/a\\\n/", "Invalid regular expression: missing /");
+    testParseFailure("//\r \n]", "Unexpected token ]");
+    testParseFailure("/*\r\n*/]", "Unexpected token ]");
+    testParseFailure("/*\n\r*/]", "Unexpected token ]");
+    testParseFailure("/*\r \n*/]", "Unexpected token ]");
+    testParseFailure("\\\\", "Unexpected token ILLEGAL");
+    testParseFailure("\\u005c", "Unexpected token ILLEGAL");
+    testParseFailure("\\x", "Unexpected token ILLEGAL");
+    testParseFailure("\\u0000", "Unexpected token ILLEGAL");
+    testParseFailure("\u200C = []", "Unexpected token ILLEGAL");
+    testParseFailure("\u200D = []", "Unexpected token ILLEGAL");
+    testParseFailure("\"\\", "Unexpected token ILLEGAL");
+    testParseFailure("\"\\u", "Unexpected token ILLEGAL");
+    testParseFailure("try { } catch() {}", "Unexpected token )");
+    testParseFailure("return", "Illegal return statement");
+    testParseFailure("break", "Illegal break statement");
+    testParseFailure("continue", "Illegal continue statement");
+    testParseFailure("switch (x) { default: continue; }", "Illegal continue statement");
+    testParseFailure("do { x } *", "Unexpected token *");
+    testParseFailure("while (true) { break x; }", "Undefined label \'x\'");
+    testParseFailure("while (true) { continue x; }", "Undefined label \'x\'");
+    testParseFailure("x: while (true) { (function () { break x; }); }", "Undefined label \'x\'");
+    testParseFailure("x: while (true) { (function () { continue x; }); }", "Undefined label \'x\'");
+    testParseFailure("x: while (true) { (function () { break; }); }", "Illegal break statement");
+    testParseFailure("x: while (true) { (function () { continue; }); }", "Illegal continue statement");
+    testParseFailure("x: while (true) { x: while (true) { } }", "Label \'x\' has already been declared");
+    testParseFailure("(function () { \'use strict\'; delete i; }())", "Delete of an unqualified identifier in strict mode.");
+    testParseFailure("(function () { \'use strict\'; with (i); }())", "Strict mode code may not include a with statement");
+    testParseFailure("function hello() {\'use strict\'; ({ i: 42, i: 42 }) }",
         "Duplicate data property in object literal not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ({ hasOwnProperty: 42, hasOwnProperty: 42 }) }",
+    testParseFailure("function hello() {\'use strict\'; ({ hasOwnProperty: 42, hasOwnProperty: 42 }) }",
         "Duplicate data property in object literal not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; var eval = 10; }",
+    testParseFailure("function hello() {\'use strict\'; var eval = 10; }",
         "Variable name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; var arguments = 10; }",
+    testParseFailure("function hello() {\'use strict\'; var arguments = 10; }",
         "Variable name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; try { } catch (eval) { } }",
+    testParseFailure("function hello() {\'use strict\'; try { } catch (eval) { } }",
         "Catch variable may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; try { } catch (arguments) { } }",
+    testParseFailure("function hello() {\'use strict\'; try { } catch (arguments) { } }",
         "Catch variable may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; eval = 10; }",
+    testParseFailure("function hello() {\'use strict\'; eval = 10; }",
         "Assignment to eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; arguments = 10; }",
+    testParseFailure("function hello() {\'use strict\'; arguments = 10; }",
         "Assignment to eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ++eval; }",
+    testParseFailure("function hello() {\'use strict\'; ++eval; }",
         "Prefix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; --eval; }",
+    testParseFailure("function hello() {\'use strict\'; --eval; }",
         "Prefix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ++arguments; }",
+    testParseFailure("function hello() {\'use strict\'; ++arguments; }",
         "Prefix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; --arguments; }",
+    testParseFailure("function hello() {\'use strict\'; --arguments; }",
         "Prefix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; eval++; }",
+    testParseFailure("function hello() {\'use strict\'; eval++; }",
         "Postfix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; eval--; }",
+    testParseFailure("function hello() {\'use strict\'; eval--; }",
         "Postfix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; arguments++; }",
+    testParseFailure("function hello() {\'use strict\'; arguments++; }",
         "Postfix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; arguments--; }",
+    testParseFailure("function hello() {\'use strict\'; arguments--; }",
         "Postfix increment/decrement may not have eval or arguments operand in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; function eval() { } }",
+    testParseFailure("function hello() {\'use strict\'; function eval() { } }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; function arguments() { } }",
+    testParseFailure("function hello() {\'use strict\'; function arguments() { } }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function eval() {\'use strict\'; }", "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function arguments() {\'use strict\'; }", "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; (function eval() { }()) }",
+    testParseFailure("function eval() {\'use strict\'; }", "Function name may not be eval or arguments in strict mode");
+    testParseFailure("function arguments() {\'use strict\'; }", "Function name may not be eval or arguments in strict mode");
+    testParseFailure("function hello() {\'use strict\'; (function eval() { }()) }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; (function arguments() { }()) }",
+    testParseFailure("function hello() {\'use strict\'; (function arguments() { }()) }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("(function eval() {\'use strict\'; })()", "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("(function arguments() {\'use strict\'; })()",
+    testParseFailure("(function eval() {\'use strict\'; })()", "Function name may not be eval or arguments in strict mode");
+    testParseFailure("(function arguments() {\'use strict\'; })()",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ({ s: function eval() { } }); }",
+    testParseFailure("function hello() {\'use strict\'; ({ s: function eval() { } }); }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("(function package() {\'use strict\'; })()", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ({ i: 10, set s(eval) { } }); }",
+    testParseFailure("(function package() {\'use strict\'; })()", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() {\'use strict\'; ({ i: 10, set s(eval) { } }); }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ({ set s(eval) { } }); }",
+    testParseFailure("function hello() {\'use strict\'; ({ set s(eval) { } }); }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() {\'use strict\'; ({ s: function s(eval) { } }); }",
+    testParseFailure("function hello() {\'use strict\'; ({ s: function s(eval) { } }); }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello(eval) {\'use strict\';}",
+    testParseFailure("function hello(eval) {\'use strict\';}",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello(arguments) {\'use strict\';}",
+    testParseFailure("function hello(arguments) {\'use strict\';}",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() { \'use strict\'; function inner(eval) {} }",
+    testParseFailure("function hello() { \'use strict\'; function inner(eval) {} }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function hello() { \'use strict\'; function inner(arguments) {} }",
+    testParseFailure("function hello() { \'use strict\'; function inner(arguments) {} }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure(" \"\\1\"; \'use strict\';", "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \'use strict\'; \"\\1\"; }", "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \'use strict\'; 021; }", "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \'use strict\'; ({ \"\\1\": 42 }); }",
+    testParseFailure(" \"\\1\"; \'use strict\';", "Octal literals are not allowed in strict mode.");
+    testParseFailure("function hello() { \'use strict\'; \"\\1\"; }", "Octal literals are not allowed in strict mode.");
+    testParseFailure("function hello() { \'use strict\'; 021; }", "Octal literals are not allowed in strict mode.");
+    testParseFailure("function hello() { \'use strict\'; ({ \"\\1\": 42 }); }",
         "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \'use strict\'; ({ 021: 42 }); }",
+    testParseFailure("function hello() { \'use strict\'; ({ 021: 42 }); }",
         "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \"octal directive\\1\"; \"use strict\"; }",
+    testParseFailure("function hello() { \"octal directive\\1\"; \"use strict\"; }",
         "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \"octal directive\\1\"; \"octal directive\\2\"; \"use strict\"; }",
+    testParseFailure("function hello() { \"octal directive\\1\"; \"octal directive\\2\"; \"use strict\"; }",
         "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \"use strict\"; function inner() { \"octal directive\\1\"; } }",
+    testParseFailure("function hello() { \"use strict\"; function inner() { \"octal directive\\1\"; } }",
         "Octal literals are not allowed in strict mode.");
-    assertParseFailure("function hello() { \"use strict\"; var implements; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var interface; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var package; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var private; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var protected; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var public; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var static; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var yield; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello() { \"use strict\"; var let; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function hello(static) { \"use strict\"; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function static() { \"use strict\"; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function eval(a) { \"use strict\"; }", "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("function arguments(a) { \"use strict\"; }",
+    testParseFailure("function hello() { \"use strict\"; var implements; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var interface; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var package; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var private; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var protected; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var public; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var static; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var yield; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello() { \"use strict\"; var let; }", "Use of future reserved word in strict mode");
+    testParseFailure("function hello(static) { \"use strict\"; }", "Use of future reserved word in strict mode");
+    testParseFailure("function static() { \"use strict\"; }", "Use of future reserved word in strict mode");
+    testParseFailure("function eval(a) { \"use strict\"; }", "Function name may not be eval or arguments in strict mode");
+    testParseFailure("function arguments(a) { \"use strict\"; }",
         "Function name may not be eval or arguments in strict mode");
-    assertParseFailure("\"use strict\"; function static() { }", "Use of future reserved word in strict mode");
-    assertParseFailure("function a(t, t) { \"use strict\"; }", "Strict mode function may not have duplicate parameter names");
-    assertParseFailure("function a(eval) { \"use strict\"; }",
+    testParseFailure("\"use strict\"; function static() { }", "Use of future reserved word in strict mode");
+    testParseFailure("function a(t, t) { \"use strict\"; }", "Strict mode function may not have duplicate parameter names");
+    testParseFailure("function a(eval) { \"use strict\"; }",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("function a(package) { \"use strict\"; }", "Use of future reserved word in strict mode");
-    assertParseFailure("function a() { \"use strict\"; function b(t, t) { }; }",
+    testParseFailure("function a(package) { \"use strict\"; }", "Use of future reserved word in strict mode");
+    testParseFailure("function a() { \"use strict\"; function b(t, t) { }; }",
         "Strict mode function may not have duplicate parameter names");
-    assertParseFailure("(function a(t, t) { \"use strict\"; })",
+    testParseFailure("(function a(t, t) { \"use strict\"; })",
         "Strict mode function may not have duplicate parameter names");
-    assertParseFailure("function a() { \"use strict\"; (function b(t, t) { }); }",
+    testParseFailure("function a() { \"use strict\"; (function b(t, t) { }); }",
         "Strict mode function may not have duplicate parameter names");
-    assertParseFailure("(function a(eval) { \"use strict\"; })",
+    testParseFailure("(function a(eval) { \"use strict\"; })",
         "Parameter name eval or arguments is not allowed in strict mode");
-    assertParseFailure("(function a(package) { \"use strict\"; })", "Use of future reserved word in strict mode");
-    assertParseFailure("__proto__: __proto__: 42;", "Label \'__proto__\' has already been declared");
-    assertParseFailure("\"use strict\"; function t(__proto__, __proto__) { }",
+    testParseFailure("(function a(package) { \"use strict\"; })", "Use of future reserved word in strict mode");
+    testParseFailure("__proto__: __proto__: 42;", "Label \'__proto__\' has already been declared");
+    testParseFailure("\"use strict\"; function t(__proto__, __proto__) { }",
         "Strict mode function may not have duplicate parameter names");
-    assertParseFailure("\"use strict\"; x = { __proto__: 42, __proto__: 43 }",
+    testParseFailure("\"use strict\"; x = { __proto__: 42, __proto__: 43 }",
         "Duplicate data property in object literal not allowed in strict mode");
-    assertParseFailure("\"use strict\"; x = { get __proto__() { }, __proto__: 43 }",
+    testParseFailure("\"use strict\"; x = { get __proto__() { }, __proto__: 43 }",
         "Object literal may not have data and accessor property with the same name");
-    assertParseFailure("var", "Unexpected end of input");
-    assertParseFailure("let", "Unexpected end of input");
-    assertParseFailure("const", "Unexpected end of input");
-    assertParseFailure("{ ;  ;  ", "Unexpected end of input");
-    assertParseFailure("({get +:3})", "Property name in object literal must be identifier, string literal or number literal");
-    assertParseFailure("({get +:3})", "Property name in object literal must be identifier, string literal or number literal");
-    assertParseFailure("function t() { ;  ;  ", "Unexpected end of input");
+    testParseFailure("var", "Unexpected end of input");
+    testParseFailure("let", "Unexpected end of input");
+    testParseFailure("const", "Unexpected end of input");
+    testParseFailure("{ ;  ;  ", "Unexpected end of input");
+    testParseFailure("({get +:3})", "Property name in object literal must be identifier, string literal or number literal");
+    testParseFailure("({get +:3})", "Property name in object literal must be identifier, string literal or number literal");
+    testParseFailure("function t() { ;  ;  ", "Unexpected end of input");
   });
 });

--- a/test/failure.js
+++ b/test/failure.js
@@ -16,9 +16,9 @@
 
 var testParseFailure = require('./assertions').testParseFailure;
 
-describe("Parser", function () {
+suite("Parser", function () {
 
-  describe("error handling", function () {
+  suite("error handling", function () {
     testParseFailure("/*", "Unexpected token ILLEGAL");
     testParseFailure("/*\r", "Unexpected token ILLEGAL");
     testParseFailure("/*\r\n", "Unexpected token ILLEGAL");

--- a/test/functions/function-declaration.js
+++ b/test/functions/function-declaration.js
@@ -20,7 +20,7 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("function declaration", function () {

--- a/test/functions/function-declaration.js
+++ b/test/functions/function-declaration.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("function declaration", function () {
+suite("Parser", function () {
+  suite("function declaration", function () {
     expect(stmt(parse("function hello() { z(); }"))).to.be.eql(
       new Shift.FunctionDeclaration(new Shift.Identifier("hello"), [], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.CallExpression(new Shift.IdentifierExpression(new Shift.Identifier("z")), [])),

--- a/test/functions/function-declaration.js
+++ b/test/functions/function-declaration.js
@@ -14,52 +14,58 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("function declaration", function () {
-    expect(stmt(parse("function hello() { z(); }"))).to.be.eql(
+    testParse("function hello() { z(); }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("hello"), [], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.CallExpression(new Shift.IdentifierExpression(new Shift.Identifier("z")), [])),
       ]))
     );
-    expect(stmt(parse("function eval() { }"))).to.be.eql(
+
+    testParse("function eval() { }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("eval"), [], new Shift.FunctionBody([], []))
     );
-    expect(stmt(parse("function arguments() { }"))).to.be.eql(
+
+    testParse("function arguments() { }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("arguments"), [], new Shift.FunctionBody([], []))
     );
-    expect(stmt(parse("function test(t, t) { }"))).to.be.eql(
+
+    testParse("function test(t, t) { }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("test"), [
         new Shift.Identifier("t"),
         new Shift.Identifier("t"),
       ], new Shift.FunctionBody([], []))
     );
-    expect(stmt(parse("function eval() { function inner() { \"use strict\" } }"))).to.be.eql(
+
+    testParse("function eval() { function inner() { \"use strict\" } }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("eval"), [], new Shift.FunctionBody([], [
         new Shift.FunctionDeclaration(new Shift.Identifier("inner"), [], new Shift.FunctionBody([new Shift.UseStrictDirective], []))
       ]))
     );
-    expect(stmt(parse("function hello(a) { z(); }"))).to.be.eql(
+
+    testParse("function hello(a) { z(); }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("hello"), [new Shift.Identifier("a")], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.CallExpression(new Shift.IdentifierExpression(new Shift.Identifier("z")), [])),
       ]))
     );
-    expect(stmt(parse("function hello(a, b) { z(); }"))).to.be.eql(
+
+    testParse("function hello(a, b) { z(); }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("hello"), [new Shift.Identifier("a"), new Shift.Identifier("b")], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.CallExpression(new Shift.IdentifierExpression(new Shift.Identifier("z")), [])),
       ]))
     );
-    expect(stmt(parse("function universe(__proto__) { }"))).to.be.eql(
+
+    testParse("function universe(__proto__) { }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("universe"), [new Shift.Identifier("__proto__")], new Shift.FunctionBody([], []))
     );
-    expect(stmt(parse("function test() { \"use strict\"\n + 42; }"))).to.be.eql(
+
+    testParse("function test() { \"use strict\"\n + 42; }", stmt,
       new Shift.FunctionDeclaration(new Shift.Identifier("test"), [], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.BinaryExpression("+", new Shift.LiteralStringExpression("use strict"), new Shift.LiteralNumericExpression(42))),
       ]))

--- a/test/functions/function-expression.js
+++ b/test/functions/function-expression.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var expr = require("../helpers").expr;
 var testEsprimaEquiv = require("../assertions").testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal numeric expression", function () {
+suite("Parser", function () {
+  suite("literal numeric expression", function () {
     expect(expr(parse("(function(){})"))).to.be.eql(
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], []))
     );

--- a/test/functions/function-expression.js
+++ b/test/functions/function-expression.js
@@ -14,33 +14,31 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
-var testEsprimaEquiv = require("../assertions").testEsprimaEquiv;
+var testParse = require("../assertions").testParse;
 
 suite("Parser", function () {
   suite("literal numeric expression", function () {
-    expect(expr(parse("(function(){})"))).to.be.eql(
+    testParse("(function(){})", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], []))
     );
-    expect(expr(parse("(function x() { y; z() });"))).to.be.eql(
+    testParse("(function x() { y; z() });", expr,
       new Shift.FunctionExpression(new Shift.Identifier("x"), [], new Shift.FunctionBody([], [
         new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("y"))),
         new Shift.ExpressionStatement(new Shift.CallExpression(new Shift.IdentifierExpression(new Shift.Identifier("z")), [])),
       ]))
     );
-    expect(expr(parse("(function eval() { });"))).to.be.eql(
+    testParse("(function eval() { });", expr,
       new Shift.FunctionExpression(new Shift.Identifier("eval"), [], new Shift.FunctionBody([], []))
     );
-    expect(expr(parse("(function arguments() { });"))).to.be.eql(
+    testParse("(function arguments() { });", expr,
       new Shift.FunctionExpression(new Shift.Identifier("arguments"), [], new Shift.FunctionBody([], []))
     );
-    expect(expr(parse("(function x(y, z) { })"))).to.be.eql(
+    testParse("(function x(y, z) { })", expr,
       new Shift.FunctionExpression(new Shift.Identifier("x"), [new Shift.Identifier("y"), new Shift.Identifier("z")], new Shift.FunctionBody([], []))
     );
+
   });
 });

--- a/test/functions/function-expression.js
+++ b/test/functions/function-expression.js
@@ -20,7 +20,7 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
-var assertEsprimaEquiv = require("../assertions").assertEsprimaEquiv;
+var testEsprimaEquiv = require("../assertions").testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal numeric expression", function () {

--- a/test/grouping.js
+++ b/test/grouping.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("grouping", function () {
+suite("Parser", function () {
+  suite("grouping", function () {
     testEsprimaEquiv("(1 + 2 ) * 3");
     testEsprimaEquiv("(1) + (2  ) + 3");
     testEsprimaEquiv("4 + 5 << (6)");

--- a/test/grouping.js
+++ b/test/grouping.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('./assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("grouping", function () {
-    assertEsprimaEquiv("(1 + 2 ) * 3");
-    assertEsprimaEquiv("(1) + (2  ) + 3");
-    assertEsprimaEquiv("4 + 5 << (6)");
+    testEsprimaEquiv("(1 + 2 ) * 3");
+    testEsprimaEquiv("(1) + (2  ) + 3");
+    testEsprimaEquiv("4 + 5 << (6)");
   });
 });

--- a/test/incompatibilities.js
+++ b/test/incompatibilities.js
@@ -21,18 +21,18 @@ var Shift = require("shift-ast");
 
 var expr = require("./helpers").expr;
 var stmt = require("./helpers").stmt;
-var assertParseFailure = require('./assertions').assertParseFailure;
+var testParseFailure = require('./assertions').testParseFailure;
 
 describe("Parser", function() {
   // programs that parse according to ES3 but either fail or parse differently according to ES5
   describe("ES5 backward incompatibilities", function() {
     // ES3: zero-width non-breaking space is allowed in an identifier
     // ES5: zero-width non-breaking space is a whitespace character
-    assertParseFailure("_\uFEFF_", "Unexpected identifier");
+    testParseFailure("_\uFEFF_", "Unexpected identifier");
 
     // ES3: a slash in a regexp character class will terminate the regexp
     // ES5: a slash is allowed within a regexp character class
-    assertParseFailure("[/[/]", "Invalid regular expression: missing /");
+    testParseFailure("[/[/]", "Invalid regular expression: missing /");
   });
 
   // programs where we choose to diverge from the ES5 specification
@@ -41,14 +41,15 @@ describe("Parser", function() {
     // ES6: variable declaration statement
     // We choose to fail here because we support ES5 with a minor addition: let/const with binding identifier.
     // This is the same decision esprima has made.
-    assertParseFailure("let[a] = b;", "Unexpected token [");
-    assertParseFailure("const[a] = b;", "Unexpected token [");
-    assertParseFailure("var let", "Unexpected token let");
-    assertParseFailure("var const", "Unexpected token const");
+    testParseFailure("let[a] = b;", "Unexpected token [");
+    testParseFailure("const[a] = b;", "Unexpected token [");
+    testParseFailure("var let", "Unexpected token let");
+    testParseFailure("var const", "Unexpected token const");
 
     // ES5: invalid program
     // ES6: function declaration within a block
     // We choose to parse this because of ubiquitous support among popular interpreters, despite disagreements about semantics.
+
     expect(stmt(parse("{ function f(){} }"))).to.be.eql(
       new Shift.BlockStatement(new Shift.Block([
         new Shift.FunctionDeclaration(new Shift.Identifier("f"), [], new Shift.FunctionBody([], []))
@@ -87,8 +88,8 @@ describe("Parser", function() {
 
     // ES5: allows any LeftHandSideExpression on the left of an assignment
     // ES6: allows only valid bindings on the left of an assignment
-    assertParseFailure("a+b=c", "Invalid left-hand side in assignment");
-    assertParseFailure("+i = 42", "Invalid left-hand side in assignment");
+    testParseFailure("a+b=c", "Invalid left-hand side in assignment");
+    testParseFailure("+i = 42", "Invalid left-hand side in assignment");
     expect(expr(parse("new a=b"))).to.be.eql(
       new Shift.AssignmentExpression(
         "=",

--- a/test/incompatibilities.js
+++ b/test/incompatibilities.js
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../").default;
 var Shift = require("shift-ast");
 
 var expr = require("./helpers").expr;
 var stmt = require("./helpers").stmt;
 var testParseFailure = require('./assertions').testParseFailure;
+var testParse = require('./assertions').testParse;
 
-suite("Parser", function() {
+suite("Parser", function () {
   // programs that parse according to ES3 but either fail or parse differently according to ES5
-  suite("ES5 backward incompatibilities", function() {
+  suite("ES5 backward incompatibilities", function () {
     // ES3: zero-width non-breaking space is allowed in an identifier
     // ES5: zero-width non-breaking space is a whitespace character
     testParseFailure("_\uFEFF_", "Unexpected identifier");
@@ -36,7 +34,7 @@ suite("Parser", function() {
   });
 
   // programs where we choose to diverge from the ES5 specification
-  suite("ES5 divergences", function() {
+  suite("ES5 divergences", function () {
     // ES5: assignment to computed member expression
     // ES6: variable declaration statement
     // We choose to fail here because we support ES5 with a minor addition: let/const with binding identifier.
@@ -50,7 +48,7 @@ suite("Parser", function() {
     // ES6: function declaration within a block
     // We choose to parse this because of ubiquitous support among popular interpreters, despite disagreements about semantics.
 
-    expect(stmt(parse("{ function f(){} }"))).to.be.eql(
+    testParse("{ function f(){} }", stmt,
       new Shift.BlockStatement(new Shift.Block([
         new Shift.FunctionDeclaration(new Shift.Identifier("f"), [], new Shift.FunctionBody([], []))
       ]))
@@ -58,10 +56,10 @@ suite("Parser", function() {
   });
 
   // programs that parse according to ES5 but either fail or parse differently according to ES6
-  suite("ES6 backward incompatibilities", function() {
+  suite("ES6 backward incompatibilities", function () {
     // ES5: in sloppy mode, future reserved words (including yield) are regular identifiers
     // ES6: yield has been moved from the future reserved words list to the keywords list
-    expect(stmt(parse("var yield = function yield(){};"))).to.be.eql(
+    testParse("var yield = function yield(){};", stmt,
       new Shift.VariableDeclarationStatement(new Shift.VariableDeclaration("var", [
         new Shift.VariableDeclarator(
           new Shift.Identifier("yield"),
@@ -72,7 +70,7 @@ suite("Parser", function() {
 
     // ES5: this declares a function-scoped variable while at the same time assigning to the block-scoped variable
     // ES6: this particular construction is explicitly disallowed
-    expect(stmt(parse("try {} catch(e) { var e = 0; }"))).to.be.eql(
+    testParse("try {} catch(e) { var e = 0; }", stmt,
       new Shift.TryCatchStatement(
         new Shift.Block([]),
         new Shift.CatchClause(
@@ -90,14 +88,14 @@ suite("Parser", function() {
     // ES6: allows only valid bindings on the left of an assignment
     testParseFailure("a+b=c", "Invalid left-hand side in assignment");
     testParseFailure("+i = 42", "Invalid left-hand side in assignment");
-    expect(expr(parse("new a=b"))).to.be.eql(
+    testParse("new a=b", expr,
       new Shift.AssignmentExpression(
         "=",
         new Shift.NewExpression(new Shift.IdentifierExpression(new Shift.Identifier("a")), []),
         new Shift.IdentifierExpression(new Shift.Identifier("b"))
       )
     );
-    expect(expr(parse(("(a+b)=c")))).to.be.eql(
+    testParse("(a+b)=c", expr,
       new Shift.AssignmentExpression(
         "=",
         new Shift.BinaryExpression(

--- a/test/incompatibilities.js
+++ b/test/incompatibilities.js
@@ -23,9 +23,9 @@ var expr = require("./helpers").expr;
 var stmt = require("./helpers").stmt;
 var testParseFailure = require('./assertions').testParseFailure;
 
-describe("Parser", function() {
+suite("Parser", function() {
   // programs that parse according to ES3 but either fail or parse differently according to ES5
-  describe("ES5 backward incompatibilities", function() {
+  suite("ES5 backward incompatibilities", function() {
     // ES3: zero-width non-breaking space is allowed in an identifier
     // ES5: zero-width non-breaking space is a whitespace character
     testParseFailure("_\uFEFF_", "Unexpected identifier");
@@ -36,7 +36,7 @@ describe("Parser", function() {
   });
 
   // programs where we choose to diverge from the ES5 specification
-  describe("ES5 divergences", function() {
+  suite("ES5 divergences", function() {
     // ES5: assignment to computed member expression
     // ES6: variable declaration statement
     // We choose to fail here because we support ES5 with a minor addition: let/const with binding identifier.
@@ -58,7 +58,7 @@ describe("Parser", function() {
   });
 
   // programs that parse according to ES5 but either fail or parse differently according to ES6
-  describe("ES6 backward incompatibilities", function() {
+  suite("ES6 backward incompatibilities", function() {
     // ES5: in sloppy mode, future reserved words (including yield) are regular identifiers
     // ES6: yield has been moved from the future reserved words list to the keywords list
     expect(stmt(parse("var yield = function yield(){};"))).to.be.eql(

--- a/test/interactions.js
+++ b/test/interactions.js
@@ -21,76 +21,80 @@ var Shift = require("shift-ast");
 
 var expr = require("./helpers").expr;
 var stmt = require("./helpers").stmt;
-var assertEsprimaEquiv = require('./assertions').assertEsprimaEquiv;
-var assertParseFailure = require('./assertions').assertParseFailure;
+var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
+var testParseFailure = require('./assertions').testParseFailure;
 
 describe("Parser", function () {
   describe("interactions", function () {
     // LiteralNumericExpression and StaticMemberExpression
-    assertEsprimaEquiv("0..toString");
-    assertEsprimaEquiv("01.toString");
-    assertParseFailure("0.toString", "Unexpected token ILLEGAL");
+    testEsprimaEquiv("0..toString");
+    testEsprimaEquiv("01.toString");
+    testParseFailure("0.toString", "Unexpected token ILLEGAL");
 
     // LeftHandSideExpressions
-    assertEsprimaEquiv("a.b(b,c)");
-    assertEsprimaEquiv("a[b](b,c)");
-    assertEsprimaEquiv("new foo().bar()");
-    assertEsprimaEquiv("new foo[bar]");
-    assertEsprimaEquiv("new foo.bar()");
-    assertEsprimaEquiv("( new foo).bar()");
-    assertEsprimaEquiv("universe[42].galaxies");
-    assertEsprimaEquiv("universe(42).galaxies");
-    assertEsprimaEquiv("universe(42).galaxies(14, 3, 77).milkyway");
-    assertEsprimaEquiv("earth.asia.Indonesia.prepareForElection(2014)");
+    testEsprimaEquiv("a.b(b,c)");
+    testEsprimaEquiv("a[b](b,c)");
+    testEsprimaEquiv("new foo().bar()");
+    testEsprimaEquiv("new foo[bar]");
+    testEsprimaEquiv("new foo.bar()");
+    testEsprimaEquiv("( new foo).bar()");
+    testEsprimaEquiv("universe[42].galaxies");
+    testEsprimaEquiv("universe(42).galaxies");
+    testEsprimaEquiv("universe(42).galaxies(14, 3, 77).milkyway");
+    testEsprimaEquiv("earth.asia.Indonesia.prepareForElection(2014)");
 
     // BinaryExpressions
-    assertEsprimaEquiv("a || b && c | d ^ e & f == g < h >>> i + j * k");
+    testEsprimaEquiv("a || b && c | d ^ e & f == g < h >>> i + j * k");
 
     // Comments
-    assertEsprimaEquiv("//\n;a;");
-    assertEsprimaEquiv("/* block comment */ 42");
-    assertEsprimaEquiv("42 /* block comment 1 */ /* block comment 2 */");
-    assertEsprimaEquiv("(a + /* assignment */b ) * c");
-    assertEsprimaEquiv("/* assignment */\n a = b");
-    assertEsprimaEquiv("42 /*The*/ /*Answer*/");
-    assertEsprimaEquiv("42 /*the*/ /*answer*/");
-    assertEsprimaEquiv("42 /* the * answer */");
-    assertEsprimaEquiv("42 /* The * answer */");
-    assertEsprimaEquiv("/* multiline\ncomment\nshould\nbe\nignored */ 42");
-    assertEsprimaEquiv("/*a\r\nb*/ 42");
-    assertEsprimaEquiv("/*a\rb*/ 42");
-    assertEsprimaEquiv("/*a\nb*/ 42");
-    assertEsprimaEquiv("/*a\nc*/ 42");
-    assertEsprimaEquiv("// line comment\n42");
-    assertEsprimaEquiv("42 // line comment");
-    assertEsprimaEquiv("// Hello, world!\n42");
-    assertEsprimaEquiv("// Hello, world!\n");
-    assertEsprimaEquiv("// Hallo, world!\n");
-    assertEsprimaEquiv("//\n42");
-    assertEsprimaEquiv("//");
-    assertEsprimaEquiv("// ");
-    assertEsprimaEquiv("/**/42");
-    assertEsprimaEquiv("42/**/");
-    assertEsprimaEquiv("// Hello, world!\n\n//   Another hello\n42");
-    assertEsprimaEquiv("if (x) { doThat() // Some comment\n }");
-    assertEsprimaEquiv("if (x) { // Some comment\ndoThat(); }");
-    assertEsprimaEquiv("if (x) { /* Some comment */ doThat() }");
-    assertEsprimaEquiv("if (x) { doThat() /* Some comment */ }");
-    assertEsprimaEquiv("switch (answer) { case 42: /* perfect */ bingo() }");
-    assertEsprimaEquiv("switch (answer) { case 42: bingo() /* perfect */ }");
-    expect(expr(parse("/* header */ (function(){ var version = 1; }).call(this)"))).to.be.eql(
-      new Shift.CallExpression(
-        new Shift.StaticMemberExpression(
-          new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
-            new Shift.VariableDeclarationStatement(new Shift.VariableDeclaration("var", [
-              new Shift.VariableDeclarator(new Shift.Identifier("version"), new Shift.LiteralNumericExpression(1)),
+    testEsprimaEquiv("//\n;a;");
+    testEsprimaEquiv("/* block comment */ 42");
+    testEsprimaEquiv("42 /* block comment 1 */ /* block comment 2 */");
+    testEsprimaEquiv("(a + /* assignment */b ) * c");
+    testEsprimaEquiv("/* assignment */\n a = b");
+    testEsprimaEquiv("42 /*The*/ /*Answer*/");
+    testEsprimaEquiv("42 /*the*/ /*answer*/");
+    testEsprimaEquiv("42 /* the * answer */");
+    testEsprimaEquiv("42 /* The * answer */");
+    testEsprimaEquiv("/* multiline\ncomment\nshould\nbe\nignored */ 42");
+    testEsprimaEquiv("/*a\r\nb*/ 42");
+    testEsprimaEquiv("/*a\rb*/ 42");
+    testEsprimaEquiv("/*a\nb*/ 42");
+    testEsprimaEquiv("/*a\nc*/ 42");
+    testEsprimaEquiv("// line comment\n42");
+    testEsprimaEquiv("42 // line comment");
+    testEsprimaEquiv("// Hello, world!\n42");
+    testEsprimaEquiv("// Hello, world!\n");
+    testEsprimaEquiv("// Hallo, world!\n");
+    testEsprimaEquiv("//\n42");
+    testEsprimaEquiv("//");
+    testEsprimaEquiv("// ");
+    testEsprimaEquiv("/**/42");
+    testEsprimaEquiv("42/**/");
+    testEsprimaEquiv("// Hello, world!\n\n//   Another hello\n42");
+    testEsprimaEquiv("if (x) { doThat() // Some comment\n }");
+    testEsprimaEquiv("if (x) { // Some comment\ndoThat(); }");
+    testEsprimaEquiv("if (x) { /* Some comment */ doThat() }");
+    testEsprimaEquiv("if (x) { doThat() /* Some comment */ }");
+    testEsprimaEquiv("switch (answer) { case 42: /* perfect */ bingo() }");
+    testEsprimaEquiv("switch (answer) { case 42: bingo() /* perfect */ }");
+
+    test(function () {
+      expect(expr(parse("/* header */ (function(){ var version = 1; }).call(this)"))).to.be.eql(
+        new Shift.CallExpression(
+          new Shift.StaticMemberExpression(
+            new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
+              new Shift.VariableDeclarationStatement(new Shift.VariableDeclaration("var", [
+                new Shift.VariableDeclarator(new Shift.Identifier("version"), new Shift.LiteralNumericExpression(1)),
+              ])),
             ])),
-          ])),
-          new Shift.Identifier("call")
-        ),
-        [new Shift.ThisExpression]
-      )
-    );
+            new Shift.Identifier("call")
+          ),
+          [new Shift.ThisExpression]
+        )
+      );
+    });
+
     expect(expr(parse("(function(){ var version = 1; /* sync */ }).call(this)"))).to.be.eql(
       new Shift.CallExpression(
         new Shift.StaticMemberExpression(
@@ -112,8 +116,8 @@ describe("Parser", function () {
         ])),
       ]))
     );
-    assertEsprimaEquiv("while (i-->0) {}");
-    assertEsprimaEquiv("var x = 1<!--foo");
-    assertEsprimaEquiv("/* not comment*/; i-->0");
+    testEsprimaEquiv("while (i-->0) {}");
+    testEsprimaEquiv("var x = 1<!--foo");
+    testEsprimaEquiv("/* not comment*/; i-->0");
   });
 });

--- a/test/interactions.js
+++ b/test/interactions.js
@@ -24,8 +24,8 @@ var stmt = require("./helpers").stmt;
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 var testParseFailure = require('./assertions').testParseFailure;
 
-describe("Parser", function () {
-  describe("interactions", function () {
+suite("Parser", function () {
+  suite("interactions", function () {
     // LiteralNumericExpression and StaticMemberExpression
     testEsprimaEquiv("0..toString");
     testEsprimaEquiv("01.toString");

--- a/test/literals/literal-infinity-expression.js
+++ b/test/literals/literal-infinity-expression.js
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
-var expect = require('expect.js');
-var ShiftParser = require('../..');
+var Shift = require("shift-ast");
 
-suite("Parser", function () {
+var expr = require("../helpers").expr;
+var testParse = require('../assertions').testParse;
+
+suite("Parser", function() {
   suite("literal infinity expression", function () {
-    expect(ShiftParser.default("2e308").body.statements[0].expression.type).to.be("LiteralInfinityExpression");
+    testParse("2e308", expr,
+      new Shift.LiteralInfinityExpression
+    );
   });
 });

--- a/test/literals/literal-infinity-expression.js
+++ b/test/literals/literal-infinity-expression.js
@@ -17,8 +17,8 @@
 var expect = require('expect.js');
 var ShiftParser = require('../..');
 
-describe("Parser", function () {
-  describe("literal infinity expression", function () {
+suite("Parser", function () {
+  suite("literal infinity expression", function () {
     expect(ShiftParser.default("2e308").body.statements[0].expression.type).to.be("LiteralInfinityExpression");
   });
 });

--- a/test/literals/literal-null-expression.js
+++ b/test/literals/literal-null-expression.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal null expression", function () {
-    assertEsprimaEquiv("null");
-    assertEsprimaEquiv("null;");
-    assertEsprimaEquiv("null\n");
+    testEsprimaEquiv("null");
+    testEsprimaEquiv("null;");
+    testEsprimaEquiv("null\n");
   });
 });

--- a/test/literals/literal-null-expression.js
+++ b/test/literals/literal-null-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal null expression", function () {
+suite("Parser", function () {
+  suite("literal null expression", function () {
     testEsprimaEquiv("null");
     testEsprimaEquiv("null;");
     testEsprimaEquiv("null\n");

--- a/test/literals/literal-numeric-expression.js
+++ b/test/literals/literal-numeric-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal numeric expression", function () {
+suite("Parser", function () {
+  suite("literal numeric expression", function () {
     testEsprimaEquiv("0");
     testEsprimaEquiv("0;");
     testEsprimaEquiv("3");

--- a/test/literals/literal-numeric-expression.js
+++ b/test/literals/literal-numeric-expression.js
@@ -14,32 +14,32 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal numeric expression", function () {
-    assertEsprimaEquiv("0");
-    assertEsprimaEquiv("0;");
-    assertEsprimaEquiv("3");
-    assertEsprimaEquiv("5");
-    assertEsprimaEquiv("42");
-    assertEsprimaEquiv(".14");
-    assertEsprimaEquiv("3.14159");
-    assertEsprimaEquiv("6.02214179e+23");
-    assertEsprimaEquiv("1.492417830e-10");
-    assertEsprimaEquiv("0x0");
-    assertEsprimaEquiv("0x0;");
-    assertEsprimaEquiv("0e+100 ");
-    assertEsprimaEquiv("0e+100");
-    assertEsprimaEquiv("0xabc");
-    assertEsprimaEquiv("0xdef");
-    assertEsprimaEquiv("0X1A");
-    assertEsprimaEquiv("0x10");
-    assertEsprimaEquiv("0x100");
-    assertEsprimaEquiv("0X04");
-    assertEsprimaEquiv("02");
-    assertEsprimaEquiv("012");
-    assertEsprimaEquiv("0012");
-    assertEsprimaEquiv("\n    42\n\n");
+    testEsprimaEquiv("0");
+    testEsprimaEquiv("0;");
+    testEsprimaEquiv("3");
+    testEsprimaEquiv("5");
+    testEsprimaEquiv("42");
+    testEsprimaEquiv(".14");
+    testEsprimaEquiv("3.14159");
+    testEsprimaEquiv("6.02214179e+23");
+    testEsprimaEquiv("1.492417830e-10");
+    testEsprimaEquiv("0x0");
+    testEsprimaEquiv("0x0;");
+    testEsprimaEquiv("0e+100 ");
+    testEsprimaEquiv("0e+100");
+    testEsprimaEquiv("0xabc");
+    testEsprimaEquiv("0xdef");
+    testEsprimaEquiv("0X1A");
+    testEsprimaEquiv("0x10");
+    testEsprimaEquiv("0x100");
+    testEsprimaEquiv("0X04");
+    testEsprimaEquiv("02");
+    testEsprimaEquiv("012");
+    testEsprimaEquiv("0012");
+    testEsprimaEquiv("\n    42\n\n");
   });
 });

--- a/test/literals/literal-regexp-expression.js
+++ b/test/literals/literal-regexp-expression.js
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal regexp expression", function () {
     // Regular Expression Literals
-    assertEsprimaEquiv("/a/");
-    assertEsprimaEquiv("/a/;");
-    assertEsprimaEquiv("/a/i");
-    assertEsprimaEquiv("/a/i;");
-    assertEsprimaEquiv("/[a-z]/i");
-    assertEsprimaEquiv("/[x-z]/i");
-    assertEsprimaEquiv("/[a-c]/i");
-    assertEsprimaEquiv("/[P QR]/i");
-    assertEsprimaEquiv("/[\\]/]/");
-    assertEsprimaEquiv("/foo\\/bar/");
-    assertEsprimaEquiv("/=([^=\\s])+/g");
-    // assertEsprimaEquiv("/[P QR]/\\g");
-    assertEsprimaEquiv("/42/g.test");
+    testEsprimaEquiv("/a/");
+    testEsprimaEquiv("/a/;");
+    testEsprimaEquiv("/a/i");
+    testEsprimaEquiv("/a/i;");
+    testEsprimaEquiv("/[a-z]/i");
+    testEsprimaEquiv("/[x-z]/i");
+    testEsprimaEquiv("/[a-c]/i");
+    testEsprimaEquiv("/[P QR]/i");
+    testEsprimaEquiv("/[\\]/]/");
+    testEsprimaEquiv("/foo\\/bar/");
+    testEsprimaEquiv("/=([^=\\s])+/g");
+    // testEsprimaEquiv("/[P QR]/\\g");
+    testEsprimaEquiv("/42/g.test");
   });
 });

--- a/test/literals/literal-regexp-expression.js
+++ b/test/literals/literal-regexp-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal regexp expression", function () {
+suite("Parser", function () {
+  suite("literal regexp expression", function () {
     // Regular Expression Literals
     testEsprimaEquiv("/a/");
     testEsprimaEquiv("/a/;");

--- a/test/literals/literal-string-expression.js
+++ b/test/literals/literal-string-expression.js
@@ -14,26 +14,16 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("literal string expression", function () {
-    expect(expr(parse("('x')"))).to.be.eql(
-      new Shift.LiteralStringExpression("x")
-    );
-    expect(expr(parse("('\\\\\\'')"))).to.be.eql(
-      new Shift.LiteralStringExpression("\\'")
-    );
-    expect(expr(parse("(\"x\")"))).to.be.eql(
-      new Shift.LiteralStringExpression("x")
-    );
-    expect(expr(parse("(\"\\\\\\\"\")"))).to.be.eql(
-      new Shift.LiteralStringExpression("\\\"")
-    );
+    testParse("('x')", expr, new Shift.LiteralStringExpression("x") );
+    testParse("('\\\\\\'')", expr, new Shift.LiteralStringExpression("\\'"));
+    testParse("(\"x\")", expr, new Shift.LiteralStringExpression("x"));
+    testParse("(\"\\\\\\\"\")", expr, new Shift.LiteralStringExpression("\\\""));
   });
 });

--- a/test/literals/literal-string-expression.js
+++ b/test/literals/literal-string-expression.js
@@ -21,8 +21,8 @@ var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
 
-describe("Parser", function () {
-  describe("literal string expression", function () {
+suite("Parser", function () {
+  suite("literal string expression", function () {
     expect(expr(parse("('x')"))).to.be.eql(
       new Shift.LiteralStringExpression("x")
     );

--- a/test/literals/literal-unary-expression.js
+++ b/test/literals/literal-unary-expression.js
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal unary expression", function () {
     // Unary Operators
-    assertEsprimaEquiv("++x");
-    assertEsprimaEquiv("--x");
-    assertEsprimaEquiv("++eval");
-    assertEsprimaEquiv("--eval");
-    assertEsprimaEquiv("++arguments");
-    assertEsprimaEquiv("--arguments");
-    assertEsprimaEquiv("+x");
-    assertEsprimaEquiv("-x");
-    assertEsprimaEquiv("~x");
-    assertEsprimaEquiv("!x");
-    assertEsprimaEquiv("void x");
-    assertEsprimaEquiv("delete x");
-    assertEsprimaEquiv("typeof x");
+    testEsprimaEquiv("++x");
+    testEsprimaEquiv("--x");
+    testEsprimaEquiv("++eval");
+    testEsprimaEquiv("--eval");
+    testEsprimaEquiv("++arguments");
+    testEsprimaEquiv("--arguments");
+    testEsprimaEquiv("+x");
+    testEsprimaEquiv("-x");
+    testEsprimaEquiv("~x");
+    testEsprimaEquiv("!x");
+    testEsprimaEquiv("void x");
+    testEsprimaEquiv("delete x");
+    testEsprimaEquiv("typeof x");
   });
 });

--- a/test/literals/literal-unary-expression.js
+++ b/test/literals/literal-unary-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal unary expression", function () {
+suite("Parser", function () {
+  suite("literal unary expression", function () {
     // Unary Operators
     testEsprimaEquiv("++x");
     testEsprimaEquiv("--x");

--- a/test/object-expressions/object-expression.js
+++ b/test/object-expressions/object-expression.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("object expression", function () {
@@ -28,129 +26,130 @@ suite("Parser", function () {
     testEsprimaEquiv("+{}");
     testEsprimaEquiv("+{ }");
 
-    expect(expr(parse("({ answer: 42 })"))).to.be.eql(
+    testParse("({ answer: 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "answer"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ if: 42 })"))).to.be.eql(
+
+    testParse("({ if: 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "if"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ true: 42 })"))).to.be.eql(
+    testParse("({ true: 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "true"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ false: 42 })"))).to.be.eql(
+    testParse("({ false: 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "false"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ null: 42 })"))).to.be.eql(
+    testParse("({ null: 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "null"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ \"answer\": 42 })"))).to.be.eql(
+    testParse("({ \"answer\": 42 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("string", "answer"), new Shift.LiteralNumericExpression(42)),
       ])
     );
-    expect(expr(parse("({ x: 1, x: 2 })"))).to.be.eql(
+    testParse("({ x: 1, x: 2 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "x"), new Shift.LiteralNumericExpression(1)),
         new Shift.DataProperty(new Shift.PropertyName("identifier", "x"), new Shift.LiteralNumericExpression(2)),
       ])
     );
 
-    expect(expr(parse("({ get width() { return m_width } })"))).to.be.eql(
+    testParse("({ get width() { return m_width } })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "width"), new Shift.FunctionBody([], [
           new Shift.ReturnStatement(new Shift.IdentifierExpression(new Shift.Identifier("m_width"))),
         ])),
       ])
     );
-    expect(expr(parse("({ get undef() {} })"))).to.be.eql(
+    testParse("({ get undef() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "undef"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get if() {} })"))).to.be.eql(
+    testParse("({ get if() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "if"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get true() {} })"))).to.be.eql(
+    testParse("({ get true() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "true"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get false() {} })"))).to.be.eql(
+    testParse("({ get false() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "false"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get null() {} })"))).to.be.eql(
+    testParse("({ get null() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "null"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get \"undef\"() {} })"))).to.be.eql(
+    testParse("({ get \"undef\"() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("string", "undef"), new Shift.FunctionBody([], [])),
       ])
     );
-    expect(expr(parse("({ get 10() {} })"))).to.be.eql(
+    testParse("({ get 10() {} })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("number", "10"), new Shift.FunctionBody([], [])),
       ])
     );
 
-    expect(expr(parse("({ set width(w) { w } })"))).to.be.eql(
+    testParse("({ set width(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("identifier", "width"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set if(w) { w } })"))).to.be.eql(
+    testParse("({ set if(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("identifier", "if"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set true(w) { w } })"))).to.be.eql(
+    testParse("({ set true(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("identifier", "true"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set false(w) { w } })"))).to.be.eql(
+    testParse("({ set false(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("identifier", "false"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set null(w) { w } })"))).to.be.eql(
+    testParse("({ set null(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("identifier", "null"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set \"null\"(w) { w } })"))).to.be.eql(
+    testParse("({ set \"null\"(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("string", "null"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
         ])),
       ])
     );
-    expect(expr(parse("({ set 10(w) { w } })"))).to.be.eql(
+    testParse("({ set 10(w) { w } })", expr,
       new Shift.ObjectExpression([
         new Shift.Setter(new Shift.PropertyName("number", "10"), new Shift.Identifier("w"), new Shift.FunctionBody([], [
           new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("w"))),
@@ -158,28 +157,28 @@ suite("Parser", function () {
       ])
     );
 
-    expect(expr(parse("({ get: 2 })"))).to.be.eql(
+    testParse("({ get: 2 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "get"), new Shift.LiteralNumericExpression(2)),
       ])
     );
-    expect(expr(parse("({ set: 2 })"))).to.be.eql(
+    testParse("({ set: 2 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "set"), new Shift.LiteralNumericExpression(2)),
       ])
     );
-    expect(expr(parse("({ __proto__: 2 })"))).to.be.eql(
+    testParse("({ __proto__: 2 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "__proto__"), new Shift.LiteralNumericExpression(2)),
       ])
     );
-    expect(expr(parse("({\"__proto__\": 2 })"))).to.be.eql(
+    testParse("({\"__proto__\": 2 })", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("string", "__proto__"), new Shift.LiteralNumericExpression(2)),
       ])
     );
 
-    expect(expr(parse("({ get width() { return width }, set width(width) { return width; } })"))).to.be.eql(
+    testParse("({ get width() { return width }, set width(width) { return width; } })", expr,
       new Shift.ObjectExpression([
         new Shift.Getter(new Shift.PropertyName("identifier", "width"), new Shift.FunctionBody([], [
           new Shift.ReturnStatement(new Shift.IdentifierExpression(new Shift.Identifier("width"))),
@@ -190,7 +189,7 @@ suite("Parser", function () {
       ])
     );
 
-    expect(expr(parse("({a:0, get 'b'(){}, set 3(d){}})"))).to.be.eql(
+    testParse("({a:0, get 'b'(){}, set 3(d){}})", expr,
       new Shift.ObjectExpression([
         new Shift.DataProperty(new Shift.PropertyName("identifier", "a"), new Shift.LiteralNumericExpression(0)),
         new Shift.Getter(new Shift.PropertyName("string", "b"), new Shift.FunctionBody([], [])),

--- a/test/object-expressions/object-expression.js
+++ b/test/object-expressions/object-expression.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var expr = require("../helpers").expr;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("object expression", function () {
+suite("Parser", function () {
+  suite("object expression", function () {
     testEsprimaEquiv("({})");
     testEsprimaEquiv("+{}");
     testEsprimaEquiv("+{ }");

--- a/test/object-expressions/object-expression.js
+++ b/test/object-expressions/object-expression.js
@@ -20,13 +20,13 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("object expression", function () {
-    assertEsprimaEquiv("({})");
-    assertEsprimaEquiv("+{}");
-    assertEsprimaEquiv("+{ }");
+    testEsprimaEquiv("({})");
+    testEsprimaEquiv("+{}");
+    testEsprimaEquiv("+{ }");
 
     expect(expr(parse("({ answer: 42 })"))).to.be.eql(
       new Shift.ObjectExpression([

--- a/test/object-expressions/property-name.js
+++ b/test/object-expressions/property-name.js
@@ -14,12 +14,23 @@
  * limitations under the License.
  */
 
-var expect = require('expect.js');
-var ShiftParser = require('../..');
+var Shift = require("shift-ast");
+
+var expr = require("../helpers").expr;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("property name", function () {
-    expect(ShiftParser.default("({0x0:0})").body.statements[0].expression.properties[0].name.value).to.be("0");
-    expect(ShiftParser.default("({2e308:0})").body.statements[0].expression.properties[0].name.value).to.be("" + 1 / 0);
+    testParse("({0x0:0})", expr,
+      new Shift.ObjectExpression([
+        new Shift.DataProperty(new Shift.PropertyName("number", "0"), new Shift.LiteralNumericExpression(0)),
+      ])
+    );
+
+    testParse("({2e308:0})", expr,
+      new Shift.ObjectExpression([
+        new Shift.DataProperty(new Shift.PropertyName("number", "" + 1 / 0), new Shift.LiteralNumericExpression(0)),
+      ])
+    );
   });
 });

--- a/test/object-expressions/property-name.js
+++ b/test/object-expressions/property-name.js
@@ -17,8 +17,8 @@
 var expect = require('expect.js');
 var ShiftParser = require('../..');
 
-describe("Parser", function () {
-  describe("property name", function () {
+suite("Parser", function () {
+  suite("property name", function () {
     expect(ShiftParser.default("({0x0:0})").body.statements[0].expression.properties[0].name.value).to.be("0");
     expect(ShiftParser.default("({2e308:0})").body.statements[0].expression.properties[0].name.value).to.be("" + 1 / 0);
   });

--- a/test/other-expressions/array-expression.js
+++ b/test/other-expressions/array-expression.js
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("array expression", function () {
-    assertEsprimaEquiv("[]");
-    assertEsprimaEquiv("[ ]");
-    assertEsprimaEquiv("[ 42 ]");
-    assertEsprimaEquiv("[ 42, ]");
-    assertEsprimaEquiv("[ ,, 42 ]");
-    assertEsprimaEquiv("[ 1, 2, 3, ]");
-    assertEsprimaEquiv("[ 1, 2,, 3, ]");
-    assertEsprimaEquiv("[,,1,,,3,4,,]");
+    testEsprimaEquiv("[]");
+    testEsprimaEquiv("[ ]");
+    testEsprimaEquiv("[ 42 ]");
+    testEsprimaEquiv("[ 42, ]");
+    testEsprimaEquiv("[ ,, 42 ]");
+    testEsprimaEquiv("[ 1, 2, 3, ]");
+    testEsprimaEquiv("[ 1, 2,, 3, ]");
+    testEsprimaEquiv("[,,1,,,3,4,,]");
   });
 });

--- a/test/other-expressions/array-expression.js
+++ b/test/other-expressions/array-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("array expression", function () {
+suite("Parser", function () {
+  suite("array expression", function () {
     testEsprimaEquiv("[]");
     testEsprimaEquiv("[ ]");
     testEsprimaEquiv("[ 42 ]");

--- a/test/other-expressions/assignment-expression.js
+++ b/test/other-expressions/assignment-expression.js
@@ -20,25 +20,25 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("assignment expression", function () {
-    assertEsprimaEquiv("a=2;");
-    assertEsprimaEquiv("x = 42");
-    assertEsprimaEquiv("eval = 42");
-    assertEsprimaEquiv("arguments = 42");
-    assertEsprimaEquiv("x *= 42");
-    assertEsprimaEquiv("x /= 42");
-    assertEsprimaEquiv("x %= 42");
-    assertEsprimaEquiv("x += 42");
-    assertEsprimaEquiv("x -= 42");
-    assertEsprimaEquiv("x <<= 42");
-    assertEsprimaEquiv("x >>= 42");
-    assertEsprimaEquiv("x >>>= 42");
-    assertEsprimaEquiv("x &= 42");
-    assertEsprimaEquiv("x ^= 42");
-    assertEsprimaEquiv("x |= 42");
+    testEsprimaEquiv("a=2;");
+    testEsprimaEquiv("x = 42");
+    testEsprimaEquiv("eval = 42");
+    testEsprimaEquiv("arguments = 42");
+    testEsprimaEquiv("x *= 42");
+    testEsprimaEquiv("x /= 42");
+    testEsprimaEquiv("x %= 42");
+    testEsprimaEquiv("x += 42");
+    testEsprimaEquiv("x -= 42");
+    testEsprimaEquiv("x <<= 42");
+    testEsprimaEquiv("x >>= 42");
+    testEsprimaEquiv("x >>>= 42");
+    testEsprimaEquiv("x &= 42");
+    testEsprimaEquiv("x ^= 42");
+    testEsprimaEquiv("x |= 42");
     expect(expr(parse("'use strict'; eval[0] = 42"))).to.be.eql(
       new Shift.AssignmentExpression(
         "=",

--- a/test/other-expressions/assignment-expression.js
+++ b/test/other-expressions/assignment-expression.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var expr = require("../helpers").expr;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("assignment expression", function () {
+suite("Parser", function () {
+  suite("assignment expression", function () {
     testEsprimaEquiv("a=2;");
     testEsprimaEquiv("x = 42");
     testEsprimaEquiv("eval = 42");

--- a/test/other-expressions/assignment-expression.js
+++ b/test/other-expressions/assignment-expression.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("assignment expression", function () {
@@ -39,7 +37,7 @@ suite("Parser", function () {
     testEsprimaEquiv("x &= 42");
     testEsprimaEquiv("x ^= 42");
     testEsprimaEquiv("x |= 42");
-    expect(expr(parse("'use strict'; eval[0] = 42"))).to.be.eql(
+    testParse("'use strict'; eval[0] = 42", expr,
       new Shift.AssignmentExpression(
         "=",
         new Shift.ComputedMemberExpression(
@@ -49,7 +47,7 @@ suite("Parser", function () {
         new Shift.LiteralNumericExpression(42)
       )
     );
-    expect(expr(parse("'use strict'; arguments[0] = 42"))).to.be.eql(
+    testParse("'use strict'; arguments[0] = 42", expr,
       new Shift.AssignmentExpression(
         "=",
         new Shift.ComputedMemberExpression(

--- a/test/other-expressions/binary-expression.js
+++ b/test/other-expressions/binary-expression.js
@@ -14,73 +14,73 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("binary expression", function () {
-    assertEsprimaEquiv("1+2;");
+    testEsprimaEquiv("1+2;");
 
     // Binary Bitwise Operators
-    assertEsprimaEquiv("x & y");
-    assertEsprimaEquiv("x ^ y");
-    assertEsprimaEquiv("x | y");
+    testEsprimaEquiv("x & y");
+    testEsprimaEquiv("x ^ y");
+    testEsprimaEquiv("x | y");
 
     // Binary Expressions
-    assertEsprimaEquiv("x + y + z");
-    assertEsprimaEquiv("x - y + z");
-    assertEsprimaEquiv("x + y - z");
-    assertEsprimaEquiv("x - y - z");
-    assertEsprimaEquiv("x + y * z");
-    assertEsprimaEquiv("x + y / z");
-    assertEsprimaEquiv("x - y % z");
-    assertEsprimaEquiv("x * y * z");
-    assertEsprimaEquiv("x * y / z");
-    assertEsprimaEquiv("x * y % z");
-    assertEsprimaEquiv("x % y * z");
-    assertEsprimaEquiv("x << y << z");
-    assertEsprimaEquiv("x | y | z");
-    assertEsprimaEquiv("x & y & z");
-    assertEsprimaEquiv("x ^ y ^ z");
-    assertEsprimaEquiv("x & y | z");
-    assertEsprimaEquiv("x | y ^ z");
-    assertEsprimaEquiv("x | y & z");
+    testEsprimaEquiv("x + y + z");
+    testEsprimaEquiv("x - y + z");
+    testEsprimaEquiv("x + y - z");
+    testEsprimaEquiv("x - y - z");
+    testEsprimaEquiv("x + y * z");
+    testEsprimaEquiv("x + y / z");
+    testEsprimaEquiv("x - y % z");
+    testEsprimaEquiv("x * y * z");
+    testEsprimaEquiv("x * y / z");
+    testEsprimaEquiv("x * y % z");
+    testEsprimaEquiv("x % y * z");
+    testEsprimaEquiv("x << y << z");
+    testEsprimaEquiv("x | y | z");
+    testEsprimaEquiv("x & y & z");
+    testEsprimaEquiv("x ^ y ^ z");
+    testEsprimaEquiv("x & y | z");
+    testEsprimaEquiv("x | y ^ z");
+    testEsprimaEquiv("x | y & z");
 
     // Binary Logical Operators
-    assertEsprimaEquiv("x || y");
-    assertEsprimaEquiv("x && y");
-    assertEsprimaEquiv("x || y || z");
-    assertEsprimaEquiv("x && y && z");
-    assertEsprimaEquiv("x || y && z");
-    assertEsprimaEquiv("x || y ^ z");
+    testEsprimaEquiv("x || y");
+    testEsprimaEquiv("x && y");
+    testEsprimaEquiv("x || y || z");
+    testEsprimaEquiv("x && y && z");
+    testEsprimaEquiv("x || y && z");
+    testEsprimaEquiv("x || y ^ z");
 
     // Multiplicative Operators
-    assertEsprimaEquiv("x * y");
-    assertEsprimaEquiv("x / y");
-    assertEsprimaEquiv("x % y");
+    testEsprimaEquiv("x * y");
+    testEsprimaEquiv("x / y");
+    testEsprimaEquiv("x % y");
 
     // Additive Operators
-    assertEsprimaEquiv("x + y");
-    assertEsprimaEquiv("x - y");
-    assertEsprimaEquiv("\"use strict\" + 42");
+    testEsprimaEquiv("x + y");
+    testEsprimaEquiv("x - y");
+    testEsprimaEquiv("\"use strict\" + 42");
 
     // Bitwise Shift Operator
-    assertEsprimaEquiv("x << y");
-    assertEsprimaEquiv("x >> y");
-    assertEsprimaEquiv("x >>> y");
+    testEsprimaEquiv("x << y");
+    testEsprimaEquiv("x >> y");
+    testEsprimaEquiv("x >>> y");
 
     // Relational Operators
-    assertEsprimaEquiv("x < y");
-    assertEsprimaEquiv("x > y");
-    assertEsprimaEquiv("x <= y");
-    assertEsprimaEquiv("x >= y");
-    assertEsprimaEquiv("x in y");
-    assertEsprimaEquiv("x instanceof y");
-    assertEsprimaEquiv("x < y < z");
+    testEsprimaEquiv("x < y");
+    testEsprimaEquiv("x > y");
+    testEsprimaEquiv("x <= y");
+    testEsprimaEquiv("x >= y");
+    testEsprimaEquiv("x in y");
+    testEsprimaEquiv("x instanceof y");
+    testEsprimaEquiv("x < y < z");
 
     // Equality Operators
-    assertEsprimaEquiv("x == y");
-    assertEsprimaEquiv("x != y");
-    assertEsprimaEquiv("x === y");
-    assertEsprimaEquiv("x !== y");
+    testEsprimaEquiv("x == y");
+    testEsprimaEquiv("x != y");
+    testEsprimaEquiv("x === y");
+    testEsprimaEquiv("x !== y");
   });
 });

--- a/test/other-expressions/binary-expression.js
+++ b/test/other-expressions/binary-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("binary expression", function () {
+suite("Parser", function () {
+  suite("binary expression", function () {
     testEsprimaEquiv("1+2;");
 
     // Binary Bitwise Operators

--- a/test/other-expressions/call-expression.js
+++ b/test/other-expressions/call-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("call expression", function () {
+suite("Parser", function () {
+  suite("call expression", function () {
     testEsprimaEquiv("a(b,c)");
     testEsprimaEquiv("foo(bar, baz)");
     testEsprimaEquiv("(    foo  )()");

--- a/test/other-expressions/call-expression.js
+++ b/test/other-expressions/call-expression.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("call expression", function () {
-    assertEsprimaEquiv("a(b,c)");
-    assertEsprimaEquiv("foo(bar, baz)");
-    assertEsprimaEquiv("(    foo  )()");
+    testEsprimaEquiv("a(b,c)");
+    testEsprimaEquiv("foo(bar, baz)");
+    testEsprimaEquiv("(    foo  )()");
   });
 });

--- a/test/other-expressions/computed-member-expression.js
+++ b/test/other-expressions/computed-member-expression.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("computed member expression", function () {
-    assertEsprimaEquiv("universe[galaxyName, otherUselessName]");
-    assertEsprimaEquiv("universe[galaxyName]");
+    testEsprimaEquiv("universe[galaxyName, otherUselessName]");
+    testEsprimaEquiv("universe[galaxyName]");
   });
 });

--- a/test/other-expressions/computed-member-expression.js
+++ b/test/other-expressions/computed-member-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("computed member expression", function () {
+suite("Parser", function () {
+  suite("computed member expression", function () {
     testEsprimaEquiv("universe[galaxyName, otherUselessName]");
     testEsprimaEquiv("universe[galaxyName]");
   });

--- a/test/other-expressions/conditional-expression.js
+++ b/test/other-expressions/conditional-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("conditional expression", function () {
+suite("Parser", function () {
+  suite("conditional expression", function () {
     testEsprimaEquiv("a?b:c");
     testEsprimaEquiv("y ? 1 : 2");
     testEsprimaEquiv("x && y ? 1 : 2");

--- a/test/other-expressions/conditional-expression.js
+++ b/test/other-expressions/conditional-expression.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("conditional expression", function () {
-    assertEsprimaEquiv("a?b:c");
-    assertEsprimaEquiv("y ? 1 : 2");
-    assertEsprimaEquiv("x && y ? 1 : 2");
-    assertEsprimaEquiv("x = (0) ? 1 : 2");
+    testEsprimaEquiv("a?b:c");
+    testEsprimaEquiv("y ? 1 : 2");
+    testEsprimaEquiv("x && y ? 1 : 2");
+    testEsprimaEquiv("x = (0) ? 1 : 2");
   });
 });

--- a/test/other-expressions/identifier-expression.js
+++ b/test/other-expressions/identifier-expression.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("identifier expression", function () {
-    assertEsprimaEquiv("x");
-    assertEsprimaEquiv("x;");
+    testEsprimaEquiv("x");
+    testEsprimaEquiv("x;");
   });
 });

--- a/test/other-expressions/identifier-expression.js
+++ b/test/other-expressions/identifier-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("identifier expression", function () {
+suite("Parser", function () {
+  suite("identifier expression", function () {
     testEsprimaEquiv("x");
     testEsprimaEquiv("x;");
   });

--- a/test/other-expressions/new-expression.js
+++ b/test/other-expressions/new-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("new expression", function () {
+suite("Parser", function () {
+  suite("new expression", function () {
     testEsprimaEquiv("new a(b,c)");
     testEsprimaEquiv("new Button");
     testEsprimaEquiv("new Button()");

--- a/test/other-expressions/new-expression.js
+++ b/test/other-expressions/new-expression.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("new expression", function () {
-    assertEsprimaEquiv("new a(b,c)");
-    assertEsprimaEquiv("new Button");
-    assertEsprimaEquiv("new Button()");
-    assertEsprimaEquiv("new Button(a)");
-    assertEsprimaEquiv("new new foo");
-    assertEsprimaEquiv("new new foo()");
+    testEsprimaEquiv("new a(b,c)");
+    testEsprimaEquiv("new Button");
+    testEsprimaEquiv("new Button()");
+    testEsprimaEquiv("new Button(a)");
+    testEsprimaEquiv("new new foo");
+    testEsprimaEquiv("new new foo()");
   });
 });

--- a/test/other-expressions/postfix-expression.js
+++ b/test/other-expressions/postfix-expression.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("postfix expression", function () {
     // Postfix Expressions
-    assertEsprimaEquiv("x++");
-    assertEsprimaEquiv("x--");
-    assertEsprimaEquiv("eval++");
-    assertEsprimaEquiv("eval--");
-    assertEsprimaEquiv("arguments++");
-    assertEsprimaEquiv("arguments--");
+    testEsprimaEquiv("x++");
+    testEsprimaEquiv("x--");
+    testEsprimaEquiv("eval++");
+    testEsprimaEquiv("eval--");
+    testEsprimaEquiv("arguments++");
+    testEsprimaEquiv("arguments--");
   });
 });

--- a/test/other-expressions/postfix-expression.js
+++ b/test/other-expressions/postfix-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("postfix expression", function () {
+suite("Parser", function () {
+  suite("postfix expression", function () {
     // Postfix Expressions
     testEsprimaEquiv("x++");
     testEsprimaEquiv("x--");

--- a/test/other-expressions/prefix-expression.js
+++ b/test/other-expressions/prefix-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("prefix expression", function () {
+suite("Parser", function () {
+  suite("prefix expression", function () {
     testEsprimaEquiv("!a");
     testEsprimaEquiv("typeof a");
     testEsprimaEquiv("void a");

--- a/test/other-expressions/prefix-expression.js
+++ b/test/other-expressions/prefix-expression.js
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("prefix expression", function () {
-    assertEsprimaEquiv("!a");
-    assertEsprimaEquiv("typeof a");
-    assertEsprimaEquiv("void a");
-    assertEsprimaEquiv("delete a");
-    assertEsprimaEquiv("+a");
-    assertEsprimaEquiv("~a");
-    assertEsprimaEquiv("++a");
-    assertEsprimaEquiv("-a");
-    assertEsprimaEquiv("--a");
+    testEsprimaEquiv("!a");
+    testEsprimaEquiv("typeof a");
+    testEsprimaEquiv("void a");
+    testEsprimaEquiv("delete a");
+    testEsprimaEquiv("+a");
+    testEsprimaEquiv("~a");
+    testEsprimaEquiv("++a");
+    testEsprimaEquiv("-a");
+    testEsprimaEquiv("--a");
   });
 });

--- a/test/other-expressions/static-member-expression.js
+++ b/test/other-expressions/static-member-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("static member expression", function () {
+suite("Parser", function () {
+  suite("static member expression", function () {
     testEsprimaEquiv("universe.milkyway");
     testEsprimaEquiv("universe.milkyway.solarsystem");
     testEsprimaEquiv("universe.milkyway.solarsystem.Earth");

--- a/test/other-expressions/static-member-expression.js
+++ b/test/other-expressions/static-member-expression.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("static member expression", function () {
-    assertEsprimaEquiv("universe.milkyway");
-    assertEsprimaEquiv("universe.milkyway.solarsystem");
-    assertEsprimaEquiv("universe.milkyway.solarsystem.Earth");
-    assertEsprimaEquiv("universe.if");
-    assertEsprimaEquiv("universe.true");
-    assertEsprimaEquiv("universe.false");
-    assertEsprimaEquiv("universe.null");
+    testEsprimaEquiv("universe.milkyway");
+    testEsprimaEquiv("universe.milkyway.solarsystem");
+    testEsprimaEquiv("universe.milkyway.solarsystem.Earth");
+    testEsprimaEquiv("universe.if");
+    testEsprimaEquiv("universe.true");
+    testEsprimaEquiv("universe.false");
+    testEsprimaEquiv("universe.null");
   });
 });

--- a/test/other-expressions/this-expression.js
+++ b/test/other-expressions/this-expression.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("this expression", function () {
+suite("Parser", function () {
+  suite("this expression", function () {
     testEsprimaEquiv("this\n");
   });
 });

--- a/test/other-expressions/this-expression.js
+++ b/test/other-expressions/this-expression.js
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("this expression", function () {
-    assertEsprimaEquiv("this\n");
+    testEsprimaEquiv("this\n");
   });
 });

--- a/test/other-nodes/script.js
+++ b/test/other-nodes/script.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("script", function () {
+suite("Parser", function () {
+  suite("script", function () {
     testEsprimaEquiv("");
     testEsprimaEquiv(" ");
   });

--- a/test/other-nodes/script.js
+++ b/test/other-nodes/script.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("script", function () {
-    assertEsprimaEquiv("");
-    assertEsprimaEquiv(" ");
+    testEsprimaEquiv("");
+    testEsprimaEquiv(" ");
   });
 });

--- a/test/other-statements/block-statement.js
+++ b/test/other-statements/block-statement.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("block statement", function () {
-    assertEsprimaEquiv("{ foo }");
-    assertEsprimaEquiv("{ doThis(); doThat(); }");
-    assertEsprimaEquiv("{}");
+    testEsprimaEquiv("{ foo }");
+    testEsprimaEquiv("{ doThis(); doThat(); }");
+    testEsprimaEquiv("{}");
   });
 });

--- a/test/other-statements/block-statement.js
+++ b/test/other-statements/block-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("block statement", function () {
+suite("Parser", function () {
+  suite("block statement", function () {
     testEsprimaEquiv("{ foo }");
     testEsprimaEquiv("{ doThis(); doThat(); }");
     testEsprimaEquiv("{}");

--- a/test/other-statements/break-statement.js
+++ b/test/other-statements/break-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("break statement", function () {
+suite("Parser", function () {
+  suite("break statement", function () {
     testEsprimaEquiv("while (true) { break }");
     testEsprimaEquiv("done: while (true) { break done }");
     testEsprimaEquiv("done: while (true) { break done; }");

--- a/test/other-statements/break-statement.js
+++ b/test/other-statements/break-statement.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("break statement", function () {
-    assertEsprimaEquiv("while (true) { break }");
-    assertEsprimaEquiv("done: while (true) { break done }");
-    assertEsprimaEquiv("done: while (true) { break done; }");
-    assertEsprimaEquiv("__proto__: while (true) { break __proto__; }");
+    testEsprimaEquiv("while (true) { break }");
+    testEsprimaEquiv("done: while (true) { break done }");
+    testEsprimaEquiv("done: while (true) { break done; }");
+    testEsprimaEquiv("__proto__: while (true) { break __proto__; }");
   });
 });

--- a/test/other-statements/continue-statement.js
+++ b/test/other-statements/continue-statement.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("continue statement", function () {
-    assertEsprimaEquiv("while (true) { continue; }");
-    assertEsprimaEquiv("while (true) { continue }");
-    assertEsprimaEquiv("done: while (true) { continue done }");
-    assertEsprimaEquiv("done: while (true) { continue done; }");
-    assertEsprimaEquiv("__proto__: while (true) { continue __proto__; }");
-    assertEsprimaEquiv("a: do continue a; while(1);");
+    testEsprimaEquiv("while (true) { continue; }");
+    testEsprimaEquiv("while (true) { continue }");
+    testEsprimaEquiv("done: while (true) { continue done }");
+    testEsprimaEquiv("done: while (true) { continue done; }");
+    testEsprimaEquiv("__proto__: while (true) { continue __proto__; }");
+    testEsprimaEquiv("a: do continue a; while(1);");
   });
 });

--- a/test/other-statements/continue-statement.js
+++ b/test/other-statements/continue-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("continue statement", function () {
+suite("Parser", function () {
+  suite("continue statement", function () {
     testEsprimaEquiv("while (true) { continue; }");
     testEsprimaEquiv("while (true) { continue }");
     testEsprimaEquiv("done: while (true) { continue done }");

--- a/test/other-statements/debugger-statement.js
+++ b/test/other-statements/debugger-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("debugger statement", function () {
+suite("Parser", function () {
+  suite("debugger statement", function () {
     testEsprimaEquiv("debugger");
     testEsprimaEquiv("debugger;");
   });

--- a/test/other-statements/debugger-statement.js
+++ b/test/other-statements/debugger-statement.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("debugger statement", function () {
-    assertEsprimaEquiv("debugger");
-    assertEsprimaEquiv("debugger;");
+    testEsprimaEquiv("debugger");
+    testEsprimaEquiv("debugger;");
   });
 });

--- a/test/other-statements/do-while-statement.js
+++ b/test/other-statements/do-while-statement.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("do while statement", function () {
-    assertEsprimaEquiv("do keep(); while (true)");
-    assertEsprimaEquiv("do keep(); while (true);");
-    assertEsprimaEquiv("do { x++; y--; } while (x < 10)");
-    assertEsprimaEquiv("{ do { } while (false) false }");
-    assertEsprimaEquiv("do continue; while(1);");
+    testEsprimaEquiv("do keep(); while (true)");
+    testEsprimaEquiv("do keep(); while (true);");
+    testEsprimaEquiv("do { x++; y--; } while (x < 10)");
+    testEsprimaEquiv("{ do { } while (false) false }");
+    testEsprimaEquiv("do continue; while(1);");
   });
 });

--- a/test/other-statements/do-while-statement.js
+++ b/test/other-statements/do-while-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("do while statement", function () {
+suite("Parser", function () {
+  suite("do while statement", function () {
     testEsprimaEquiv("do keep(); while (true)");
     testEsprimaEquiv("do keep(); while (true);");
     testEsprimaEquiv("do { x++; y--; } while (x < 10)");

--- a/test/other-statements/empty-statement.js
+++ b/test/other-statements/empty-statement.js
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("empty expression", function () {
     // Empty Statement
-    assertEsprimaEquiv(";");
+    testEsprimaEquiv(";");
   });
 });

--- a/test/other-statements/empty-statement.js
+++ b/test/other-statements/empty-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("empty expression", function () {
+suite("Parser", function () {
+  suite("empty expression", function () {
     // Empty Statement
     testEsprimaEquiv(";");
   });

--- a/test/other-statements/expression-statement.js
+++ b/test/other-statements/expression-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("expression statement", function () {
+suite("Parser", function () {
+  suite("expression statement", function () {
     // Expression Statement
     testEsprimaEquiv("x");
     testEsprimaEquiv("x, y");

--- a/test/other-statements/expression-statement.js
+++ b/test/other-statements/expression-statement.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("expression statement", function () {
     // Expression Statement
-    assertEsprimaEquiv("x");
-    assertEsprimaEquiv("x, y");
-    assertEsprimaEquiv("\\u0061");
-    assertEsprimaEquiv("a\\u0061");
-    assertEsprimaEquiv("\\u0061a");
-    assertEsprimaEquiv("\\u0061a ");
+    testEsprimaEquiv("x");
+    testEsprimaEquiv("x, y");
+    testEsprimaEquiv("\\u0061");
+    testEsprimaEquiv("a\\u0061");
+    testEsprimaEquiv("\\u0061a");
+    testEsprimaEquiv("\\u0061a ");
   });
 });

--- a/test/other-statements/for-in-statement.js
+++ b/test/other-statements/for-in-statement.js
@@ -20,16 +20,16 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("for in statement", function () {
-    assertEsprimaEquiv("for(x in list) process(x);");
-    assertEsprimaEquiv("for (var x in list) process(x);");
-    assertEsprimaEquiv("for (var x = 42 in list) process(x);");
-    assertEsprimaEquiv("for (let x in list) process(x);");
-    assertEsprimaEquiv("for (var x = y = z in q);");
-    assertEsprimaEquiv("for (var a = b = c = (d in e) in z);");
+    testEsprimaEquiv("for(x in list) process(x);");
+    testEsprimaEquiv("for (var x in list) process(x);");
+    testEsprimaEquiv("for (var x = 42 in list) process(x);");
+    testEsprimaEquiv("for (let x in list) process(x);");
+    testEsprimaEquiv("for (var x = y = z in q);");
+    testEsprimaEquiv("for (var a = b = c = (d in e) in z);");
     expect(stmt(parse("for (var i = function() { return 10 in [] } in list) process(x);"))).to.be.eql(
       new Shift.ForInStatement(
         new Shift.VariableDeclaration("var", [
@@ -47,9 +47,9 @@ describe("Parser", function () {
         ))
       )
     );
-    assertEsprimaEquiv("for(var a in b);");
-    assertEsprimaEquiv("for(var a = c in b);");
-    assertEsprimaEquiv("for(a in b);");
-    assertEsprimaEquiv("for(a.b in b);");
+    testEsprimaEquiv("for(var a in b);");
+    testEsprimaEquiv("for(var a = c in b);");
+    testEsprimaEquiv("for(a in b);");
+    testEsprimaEquiv("for(a.b in b);");
   });
 });

--- a/test/other-statements/for-in-statement.js
+++ b/test/other-statements/for-in-statement.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("for in statement", function () {
+suite("Parser", function () {
+  suite("for in statement", function () {
     testEsprimaEquiv("for(x in list) process(x);");
     testEsprimaEquiv("for (var x in list) process(x);");
     testEsprimaEquiv("for (var x = 42 in list) process(x);");

--- a/test/other-statements/for-in-statement.js
+++ b/test/other-statements/for-in-statement.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("for in statement", function () {
@@ -30,7 +28,7 @@ suite("Parser", function () {
     testEsprimaEquiv("for (let x in list) process(x);");
     testEsprimaEquiv("for (var x = y = z in q);");
     testEsprimaEquiv("for (var a = b = c = (d in e) in z);");
-    expect(stmt(parse("for (var i = function() { return 10 in [] } in list) process(x);"))).to.be.eql(
+    testParse("for (var i = function() { return 10 in [] } in list) process(x);", stmt,
       new Shift.ForInStatement(
         new Shift.VariableDeclaration("var", [
           new Shift.VariableDeclarator(
@@ -42,8 +40,7 @@ suite("Parser", function () {
         ]),
         new Shift.IdentifierExpression(new Shift.Identifier("list")),
         new Shift.ExpressionStatement(new Shift.CallExpression(
-          new Shift.IdentifierExpression(new Shift.Identifier("process")),
-          [new Shift.IdentifierExpression(new Shift.Identifier("x"))]
+          new Shift.IdentifierExpression(new Shift.Identifier("process")), [new Shift.IdentifierExpression(new Shift.Identifier("x"))]
         ))
       )
     );

--- a/test/other-statements/for-statement.js
+++ b/test/other-statements/for-statement.js
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("for statement", function () {
-    assertEsprimaEquiv("for(;;);");
-    assertEsprimaEquiv("for(;;){}");
-    assertEsprimaEquiv("for(x = 0;;);");
-    assertEsprimaEquiv("for(var x = 0;;);");
-    assertEsprimaEquiv("for(let x = 0;;);");
-    assertEsprimaEquiv("for(var x = 0, y = 1;;);");
-    assertEsprimaEquiv("for(x = 0; x < 42;);");
-    assertEsprimaEquiv("for(x = 0; x < 42; x++);");
-    assertEsprimaEquiv("for(x = 0; x < 42; x++) process(x);");
-    assertEsprimaEquiv("for(a;b;c);");
-    assertEsprimaEquiv("for(var a;b;c);");
-    assertEsprimaEquiv("for(var a = 0;b;c);");
-    assertEsprimaEquiv("for(;b;c);");
+    testEsprimaEquiv("for(;;);");
+    testEsprimaEquiv("for(;;){}");
+    testEsprimaEquiv("for(x = 0;;);");
+    testEsprimaEquiv("for(var x = 0;;);");
+    testEsprimaEquiv("for(let x = 0;;);");
+    testEsprimaEquiv("for(var x = 0, y = 1;;);");
+    testEsprimaEquiv("for(x = 0; x < 42;);");
+    testEsprimaEquiv("for(x = 0; x < 42; x++);");
+    testEsprimaEquiv("for(x = 0; x < 42; x++) process(x);");
+    testEsprimaEquiv("for(a;b;c);");
+    testEsprimaEquiv("for(var a;b;c);");
+    testEsprimaEquiv("for(var a = 0;b;c);");
+    testEsprimaEquiv("for(;b;c);");
   });
 });

--- a/test/other-statements/for-statement.js
+++ b/test/other-statements/for-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("for statement", function () {
+suite("Parser", function () {
+  suite("for statement", function () {
     testEsprimaEquiv("for(;;);");
     testEsprimaEquiv("for(;;){}");
     testEsprimaEquiv("for(x = 0;;);");

--- a/test/other-statements/if-statement.js
+++ b/test/other-statements/if-statement.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("if statement", function () {
+suite("Parser", function () {
+  suite("if statement", function () {
     testEsprimaEquiv("if (morning) goodMorning()");
     expect(stmt(parse("if (morning) (function(){})"))).to.be.eql(
       new Shift.IfStatement(

--- a/test/other-statements/if-statement.js
+++ b/test/other-statements/if-statement.js
@@ -14,18 +14,16 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("if statement", function () {
     testEsprimaEquiv("if (morning) goodMorning()");
-    expect(stmt(parse("if (morning) (function(){})"))).to.be.eql(
+    testParse("if (morning) (function(){})", stmt,
       new Shift.IfStatement(
         new Shift.IdentifierExpression(new Shift.Identifier("morning")),
         new Shift.ExpressionStatement(new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], []))),
@@ -33,7 +31,7 @@ suite("Parser", function () {
       )
     );
     testEsprimaEquiv("if (morning) var x = 0;");
-    expect(stmt(parse("if (morning) function a(){}"))).to.be.eql(
+    testParse("if (morning) function a(){}", stmt,
       new Shift.IfStatement(
         new Shift.IdentifierExpression(new Shift.Identifier("morning")),
         new Shift.FunctionDeclaration(new Shift.Identifier("a"), [], new Shift.FunctionBody([], [])),

--- a/test/other-statements/if-statement.js
+++ b/test/other-statements/if-statement.js
@@ -20,11 +20,11 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("if statement", function () {
-    assertEsprimaEquiv("if (morning) goodMorning()");
+    testEsprimaEquiv("if (morning) goodMorning()");
     expect(stmt(parse("if (morning) (function(){})"))).to.be.eql(
       new Shift.IfStatement(
         new Shift.IdentifierExpression(new Shift.Identifier("morning")),
@@ -32,7 +32,7 @@ describe("Parser", function () {
         null
       )
     );
-    assertEsprimaEquiv("if (morning) var x = 0;");
+    testEsprimaEquiv("if (morning) var x = 0;");
     expect(stmt(parse("if (morning) function a(){}"))).to.be.eql(
       new Shift.IfStatement(
         new Shift.IdentifierExpression(new Shift.Identifier("morning")),
@@ -40,8 +40,8 @@ describe("Parser", function () {
         null
       )
     );
-    assertEsprimaEquiv("if (morning) goodMorning(); else goodDay()");
-    assertEsprimaEquiv("if(a)b;");
-    assertEsprimaEquiv("if(a)b;else c;");
+    testEsprimaEquiv("if (morning) goodMorning(); else goodDay()");
+    testEsprimaEquiv("if(a)b;");
+    testEsprimaEquiv("if(a)b;else c;");
   });
 });

--- a/test/other-statements/labeled-statement.js
+++ b/test/other-statements/labeled-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("labeled statement", function () {
+suite("Parser", function () {
+  suite("labeled statement", function () {
     testEsprimaEquiv("start: for (;;) break start");
     testEsprimaEquiv("start: while (true) break start");
     testEsprimaEquiv("__proto__: test");

--- a/test/other-statements/labeled-statement.js
+++ b/test/other-statements/labeled-statement.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("labeled statement", function () {
-    assertEsprimaEquiv("start: for (;;) break start");
-    assertEsprimaEquiv("start: while (true) break start");
-    assertEsprimaEquiv("__proto__: test");
-    assertEsprimaEquiv("a:{break a;}");
+    testEsprimaEquiv("start: for (;;) break start");
+    testEsprimaEquiv("start: while (true) break start");
+    testEsprimaEquiv("__proto__: test");
+    testEsprimaEquiv("a:{break a;}");
   });
 });

--- a/test/other-statements/return-statement.js
+++ b/test/other-statements/return-statement.js
@@ -21,8 +21,8 @@ var Shift = require("shift-ast");
 
 var expr = require("../helpers").expr;
 
-describe("Parser", function () {
-  describe("return statement", function () {
+suite("Parser", function () {
+  suite("return statement", function () {
     expect(expr(parse("(function(){ return })"))).to.be.eql(
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),

--- a/test/other-statements/return-statement.js
+++ b/test/other-statements/return-statement.js
@@ -14,31 +14,29 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
+var testParse = require('../assertions').testParse;
 var expr = require("../helpers").expr;
 
 suite("Parser", function () {
   suite("return statement", function () {
-    expect(expr(parse("(function(){ return })"))).to.be.eql(
+    testParse("(function(){ return })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),
       ]))
     );
-    expect(expr(parse("(function(){ return; })"))).to.be.eql(
+    testParse("(function(){ return; })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),
       ]))
     );
-    expect(expr(parse("(function(){ return x; })"))).to.be.eql(
+    testParse("(function(){ return x; })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(new Shift.IdentifierExpression(new Shift.Identifier("x"))),
       ]))
     );
-    expect(expr(parse("(function(){ return x * y })"))).to.be.eql(
+    testParse("(function(){ return x * y })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(new Shift.BinaryExpression("*", new Shift.IdentifierExpression(new Shift.Identifier("x")), new Shift.IdentifierExpression(new Shift.Identifier("y")))),
       ]))

--- a/test/other-statements/switch-statement.js
+++ b/test/other-statements/switch-statement.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("switch statement", function () {
-    assertEsprimaEquiv("switch (x) {}");
-    assertEsprimaEquiv("switch(a){case 1:}");
-    assertEsprimaEquiv("switch (answer) { case 42: hi(); break; }");
-    assertEsprimaEquiv("switch (answer) { case 42: hi(); break; default: break }");
+    testEsprimaEquiv("switch (x) {}");
+    testEsprimaEquiv("switch(a){case 1:}");
+    testEsprimaEquiv("switch (answer) { case 42: hi(); break; }");
+    testEsprimaEquiv("switch (answer) { case 42: hi(); break; default: break }");
   });
 });

--- a/test/other-statements/switch-statement.js
+++ b/test/other-statements/switch-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("switch statement", function () {
+suite("Parser", function () {
+  suite("switch statement", function () {
     testEsprimaEquiv("switch (x) {}");
     testEsprimaEquiv("switch(a){case 1:}");
     testEsprimaEquiv("switch (answer) { case 42: hi(); break; }");

--- a/test/other-statements/switch-with-default-statement.js
+++ b/test/other-statements/switch-with-default-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("switch with default statement", function () {
+suite("Parser", function () {
+  suite("switch with default statement", function () {
     testEsprimaEquiv("switch(a){case 1:default:case 2:}");
     testEsprimaEquiv("switch(a){case 1:default:}");
     testEsprimaEquiv("switch(a){default:case 2:}");

--- a/test/other-statements/switch-with-default-statement.js
+++ b/test/other-statements/switch-with-default-statement.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("switch with default statement", function () {
-    assertEsprimaEquiv("switch(a){case 1:default:case 2:}");
-    assertEsprimaEquiv("switch(a){case 1:default:}");
-    assertEsprimaEquiv("switch(a){default:case 2:}");
+    testEsprimaEquiv("switch(a){case 1:default:case 2:}");
+    testEsprimaEquiv("switch(a){case 1:default:}");
+    testEsprimaEquiv("switch(a){default:case 2:}");
   });
 });

--- a/test/other-statements/throw-statement.js
+++ b/test/other-statements/throw-statement.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("throw statement", function () {
-    assertEsprimaEquiv("throw this");
-    assertEsprimaEquiv("throw x;");
-    assertEsprimaEquiv("throw x * y");
-    assertEsprimaEquiv("throw {}");
+    testEsprimaEquiv("throw this");
+    testEsprimaEquiv("throw x;");
+    testEsprimaEquiv("throw x * y");
+    testEsprimaEquiv("throw {}");
   });
 });

--- a/test/other-statements/throw-statement.js
+++ b/test/other-statements/throw-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("throw statement", function () {
+suite("Parser", function () {
+  suite("throw statement", function () {
     testEsprimaEquiv("throw this");
     testEsprimaEquiv("throw x;");
     testEsprimaEquiv("throw x * y");

--- a/test/other-statements/try-catch-statement.js
+++ b/test/other-statements/try-catch-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal numeric expression", function () {
+suite("Parser", function () {
+  suite("literal numeric expression", function () {
     testEsprimaEquiv("try{}catch(a){}");
     testEsprimaEquiv("try { } catch (e) { }");
     testEsprimaEquiv("try { } catch (eval) { }");

--- a/test/other-statements/try-catch-statement.js
+++ b/test/other-statements/try-catch-statement.js
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal numeric expression", function () {
-    assertEsprimaEquiv("try{}catch(a){}");
-    assertEsprimaEquiv("try { } catch (e) { }");
-    assertEsprimaEquiv("try { } catch (eval) { }");
-    assertEsprimaEquiv("try { } catch (arguments) { }");
-    assertEsprimaEquiv("try { } catch (e) { say(e) }");
-    assertEsprimaEquiv("try { doThat(); } catch (e) { say(e) }");
+    testEsprimaEquiv("try{}catch(a){}");
+    testEsprimaEquiv("try { } catch (e) { }");
+    testEsprimaEquiv("try { } catch (eval) { }");
+    testEsprimaEquiv("try { } catch (arguments) { }");
+    testEsprimaEquiv("try { } catch (e) { say(e) }");
+    testEsprimaEquiv("try { doThat(); } catch (e) { say(e) }");
   });
 });

--- a/test/other-statements/try-finally-statement.js
+++ b/test/other-statements/try-finally-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("literal numeric expression", function () {
+suite("Parser", function () {
+  suite("literal numeric expression", function () {
     testEsprimaEquiv("try { } finally { cleanup(stuff) }");
     testEsprimaEquiv("try{}catch(a){}finally{}");
     testEsprimaEquiv("try { doThat(); } catch (e) { say(e) } finally { cleanup(stuff) }");

--- a/test/other-statements/try-finally-statement.js
+++ b/test/other-statements/try-finally-statement.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("literal numeric expression", function () {
-    assertEsprimaEquiv("try { } finally { cleanup(stuff) }");
-    assertEsprimaEquiv("try{}catch(a){}finally{}");
-    assertEsprimaEquiv("try { doThat(); } catch (e) { say(e) } finally { cleanup(stuff) }");
+    testEsprimaEquiv("try { } finally { cleanup(stuff) }");
+    testEsprimaEquiv("try{}catch(a){}finally{}");
+    testEsprimaEquiv("try { doThat(); } catch (e) { say(e) } finally { cleanup(stuff) }");
   });
 });

--- a/test/other-statements/variable-declaration-statement.js
+++ b/test/other-statements/variable-declaration-statement.js
@@ -20,19 +20,19 @@ var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("variable declaration statement", function () {
     // Variable Statement
-    assertEsprimaEquiv("var x");
-    assertEsprimaEquiv("var a;");
-    assertEsprimaEquiv("var x, y;");
-    assertEsprimaEquiv("var x = 42");
-    assertEsprimaEquiv("var eval = 42, arguments = 42");
-    assertEsprimaEquiv("var x = 14, y = 3, z = 1977");
-    assertEsprimaEquiv("var implements, interface, package");
-    assertEsprimaEquiv("var private, protected, public, static");
+    testEsprimaEquiv("var x");
+    testEsprimaEquiv("var a;");
+    testEsprimaEquiv("var x, y;");
+    testEsprimaEquiv("var x = 42");
+    testEsprimaEquiv("var eval = 42, arguments = 42");
+    testEsprimaEquiv("var x = 14, y = 3, z = 1977");
+    testEsprimaEquiv("var implements, interface, package");
+    testEsprimaEquiv("var private, protected, public, static");
     expect(stmt(parse("var yield;"))).to.be.eql(
       new Shift.VariableDeclarationStatement(new Shift.VariableDeclaration("var", [
         new Shift.VariableDeclarator(new Shift.Identifier("yield"), null),
@@ -40,14 +40,14 @@ describe("Parser", function () {
     );
 
     // Let Statement
-    assertEsprimaEquiv("let x");
-    assertEsprimaEquiv("{ let x }");
-    assertEsprimaEquiv("{ let x = 42 }");
-    assertEsprimaEquiv("{ let x = 14, y = 3, z = 1977 }");
+    testEsprimaEquiv("let x");
+    testEsprimaEquiv("{ let x }");
+    testEsprimaEquiv("{ let x = 42 }");
+    testEsprimaEquiv("{ let x = 14, y = 3, z = 1977 }");
 
     // Const Statement
-    assertEsprimaEquiv("const x = 42");
-    assertEsprimaEquiv("{ const x = 42 }");
-    assertEsprimaEquiv("{ const x = 14, y = 3, z = 1977 }");
+    testEsprimaEquiv("const x = 42");
+    testEsprimaEquiv("{ const x = 42 }");
+    testEsprimaEquiv("{ const x = 14, y = 3, z = 1977 }");
   });
 });

--- a/test/other-statements/variable-declaration-statement.js
+++ b/test/other-statements/variable-declaration-statement.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../..").default;
 var Shift = require("shift-ast");
 
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
+var testParse = require('../assertions').testParse;
 
 suite("Parser", function () {
   suite("variable declaration statement", function () {
@@ -33,7 +31,7 @@ suite("Parser", function () {
     testEsprimaEquiv("var x = 14, y = 3, z = 1977");
     testEsprimaEquiv("var implements, interface, package");
     testEsprimaEquiv("var private, protected, public, static");
-    expect(stmt(parse("var yield;"))).to.be.eql(
+    testParse("var yield;", stmt,
       new Shift.VariableDeclarationStatement(new Shift.VariableDeclaration("var", [
         new Shift.VariableDeclarator(new Shift.Identifier("yield"), null),
       ]))

--- a/test/other-statements/variable-declaration-statement.js
+++ b/test/other-statements/variable-declaration-statement.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var stmt = require("../helpers").stmt;
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("variable declaration statement", function () {
+suite("Parser", function () {
+  suite("variable declaration statement", function () {
     // Variable Statement
     testEsprimaEquiv("var x");
     testEsprimaEquiv("var a;");

--- a/test/other-statements/while-statement.js
+++ b/test/other-statements/while-statement.js
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("while statement", function () {
-    assertEsprimaEquiv("while(1);");
-    assertEsprimaEquiv("while (true) doSomething()");
-    assertEsprimaEquiv("while (x < 10) { x++; y--; }");
+    testEsprimaEquiv("while(1);");
+    testEsprimaEquiv("while (true) doSomething()");
+    testEsprimaEquiv("while (x < 10) { x++; y--; }");
   });
 });

--- a/test/other-statements/while-statement.js
+++ b/test/other-statements/while-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("while statement", function () {
+suite("Parser", function () {
+  suite("while statement", function () {
     testEsprimaEquiv("while(1);");
     testEsprimaEquiv("while (true) doSomething()");
     testEsprimaEquiv("while (x < 10) { x++; y--; }");

--- a/test/other-statements/with-statement.js
+++ b/test/other-statements/with-statement.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("with statement", function () {
+suite("Parser", function () {
+  suite("with statement", function () {
     testEsprimaEquiv("with(1);");
     testEsprimaEquiv("with (x) foo = bar");
     testEsprimaEquiv("with (x) foo = bar;");

--- a/test/other-statements/with-statement.js
+++ b/test/other-statements/with-statement.js
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('../assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('../assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("with statement", function () {
-    assertEsprimaEquiv("with(1);");
-    assertEsprimaEquiv("with (x) foo = bar");
-    assertEsprimaEquiv("with (x) foo = bar;");
-    assertEsprimaEquiv("with (x) { foo = bar }");
+    testEsprimaEquiv("with(1);");
+    testEsprimaEquiv("with (x) foo = bar");
+    testEsprimaEquiv("with (x) foo = bar;");
+    testEsprimaEquiv("with (x) { foo = bar }");
   });
 });

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-var assertEsprimaEquiv = require('./assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("unicode", function () {
     // Unicode
-    assertEsprimaEquiv("日本語 = []");
-    assertEsprimaEquiv("T\u203F = []");
-    assertEsprimaEquiv("T\u200C = []");
-    assertEsprimaEquiv("T\u200D = []");
-    assertEsprimaEquiv("\u2163\u2161 = []");
-    assertEsprimaEquiv("\u2163\u2161\u200A=\u2009[]");
+    testEsprimaEquiv("日本語 = []");
+    testEsprimaEquiv("T\u203F = []");
+    testEsprimaEquiv("T\u200C = []");
+    testEsprimaEquiv("T\u200D = []");
+    testEsprimaEquiv("\u2163\u2161 = []");
+    testEsprimaEquiv("\u2163\u2161\u200A=\u2009[]");
   });
 });

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -16,8 +16,8 @@
 
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("unicode", function () {
+suite("Parser", function () {
+  suite("unicode", function () {
     // Unicode
     testEsprimaEquiv("日本語 = []");
     testEsprimaEquiv("T\u203F = []");

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -20,21 +20,21 @@ var parse = require("../").default;
 var Shift = require("shift-ast");
 
 var expr = require("./helpers").expr;
-var assertEsprimaEquiv = require('./assertions').assertEsprimaEquiv;
+var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
 describe("Parser", function () {
   describe("automatic semicolon insertion", function () {
-    assertEsprimaEquiv("{ x\n++y }");
-    assertEsprimaEquiv("{ x\n--y }");
-    assertEsprimaEquiv("{ var x = 14, y = 3\nz; }");
+    testEsprimaEquiv("{ x\n++y }");
+    testEsprimaEquiv("{ x\n--y }");
+    testEsprimaEquiv("{ var x = 14, y = 3\nz; }");
 
-    assertEsprimaEquiv("while (true) { continue\nthere; }");
-    assertEsprimaEquiv("while (true) { continue // Comment\nthere; }");
-    assertEsprimaEquiv("while (true) { continue /* Multiline\nComment */there; }");
+    testEsprimaEquiv("while (true) { continue\nthere; }");
+    testEsprimaEquiv("while (true) { continue // Comment\nthere; }");
+    testEsprimaEquiv("while (true) { continue /* Multiline\nComment */there; }");
 
-    assertEsprimaEquiv("while (true) { break\nthere; }");
-    assertEsprimaEquiv("while (true) { break // Comment\nthere; }");
-    assertEsprimaEquiv("while (true) { break /* Multiline\nComment */there; }");
+    testEsprimaEquiv("while (true) { break\nthere; }");
+    testEsprimaEquiv("while (true) { break // Comment\nthere; }");
+    testEsprimaEquiv("while (true) { break /* Multiline\nComment */there; }");
 
     expect(expr(parse("(function(){ return\nx; })"))).to.be.eql(
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
@@ -55,13 +55,13 @@ describe("Parser", function () {
       ]))
     );
 
-    assertEsprimaEquiv("{ throw error\nerror; }");
-    assertEsprimaEquiv("{ throw error// Comment\nerror; }");
-    assertEsprimaEquiv("{ throw error/* Multiline\nComment */error; }");
+    testEsprimaEquiv("{ throw error\nerror; }");
+    testEsprimaEquiv("{ throw error// Comment\nerror; }");
+    testEsprimaEquiv("{ throw error/* Multiline\nComment */error; }");
   });
 
   describe("whitespace characters", function () {
-    assertEsprimaEquiv("new\u0020\u0009\u000B\u000C\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\uFEFFa");
-    assertEsprimaEquiv("{0\n1\r2\u20283\u20294}");
+    testEsprimaEquiv("new\u0020\u0009\u000B\u000C\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\uFEFFa");
+    testEsprimaEquiv("{0\n1\r2\u20283\u20294}");
   });
 });

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -22,8 +22,8 @@ var Shift = require("shift-ast");
 var expr = require("./helpers").expr;
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
 
-describe("Parser", function () {
-  describe("automatic semicolon insertion", function () {
+suite("Parser", function () {
+  suite("automatic semicolon insertion", function () {
     testEsprimaEquiv("{ x\n++y }");
     testEsprimaEquiv("{ x\n--y }");
     testEsprimaEquiv("{ var x = 14, y = 3\nz; }");
@@ -60,7 +60,7 @@ describe("Parser", function () {
     testEsprimaEquiv("{ throw error/* Multiline\nComment */error; }");
   });
 
-  describe("whitespace characters", function () {
+  suite("whitespace characters", function () {
     testEsprimaEquiv("new\u0020\u0009\u000B\u000C\u00A0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\uFEFFa");
     testEsprimaEquiv("{0\n1\r2\u20283\u20294}");
   });

--- a/test/whitespace.js
+++ b/test/whitespace.js
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-var expect = require("expect.js");
-
-var parse = require("../").default;
 var Shift = require("shift-ast");
 
 var expr = require("./helpers").expr;
 var testEsprimaEquiv = require('./assertions').testEsprimaEquiv;
+var testParse = require('./assertions').testParse;
 
 suite("Parser", function () {
   suite("automatic semicolon insertion", function () {
@@ -36,19 +34,19 @@ suite("Parser", function () {
     testEsprimaEquiv("while (true) { break // Comment\nthere; }");
     testEsprimaEquiv("while (true) { break /* Multiline\nComment */there; }");
 
-    expect(expr(parse("(function(){ return\nx; })"))).to.be.eql(
+    testParse("(function(){ return\nx; })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),
         new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("x"))),
       ]))
     );
-    expect(expr(parse("(function(){ return // Comment\nx; })"))).to.be.eql(
+    testParse("(function(){ return // Comment\nx; })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),
         new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("x"))),
       ]))
     );
-    expect(expr(parse("(function(){ return/* Multiline\nComment */x; })"))).to.be.eql(
+    testParse("(function(){ return/* Multiline\nComment */x; })", expr,
       new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], [
         new Shift.ReturnStatement(null),
         new Shift.ExpressionStatement(new Shift.IdentifierExpression(new Shift.Identifier("x"))),


### PR DESCRIPTION
Fixes #46 

Introduces a new utility function, `testParse`, which takes two arguments: 

1. A string representing a program
1. A callback function that accepts a Shift-parsed program. The callback function is invoked as part of a Mocha `test` call.

Example:

```javascript
testParse("(function(){})", function (parsed) {
  expect(expr(parsed)).to.be.eql(
    new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], []))
  )
});
```

Is equivalent to:

```javascript
test("(function(){})", function () {
  expect(ShiftParser.default("(function(){})")).to.be.eql(
  	new Shift.FunctionExpression(null, [], new Shift.FunctionBody([], []))
  )
});
```

The main purpose of `testParse` is to ensure that the Mocha test description is the same as the program string being parsed (for purposes of nice reporting), and also reduce the need to call `ShiftParser.default`.