### PR TITLE
fix benchmark script and add additional benchmark targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,15 +28,18 @@
   "devDependencies": {
     "angular": "1.3.14",
     "babel": "4.7.13",
+    "babel-core": "^5.1.11",
     "benchmark": "^1.0.0",
     "commonjs-everywhere": "0.9.7",
+    "esprima": "^2.2.0",
     "everything.js": "^1.0.0",
     "expect.js": "0.3.1",
     "istanbul": "0.3.8",
     "microtime": "^1.2.0",
     "mocha": "2.2.1",
+    "shift-spec": "2.1.1",
     "tick": "^0.1.1",
-    "shift-spec": "2.1.1"
+    "traceur": "0.0.88"
   },
   "keywords": [
     "Shift",


### PR DESCRIPTION
Current output (will be much more favourable for us after two-phase parsing is merged):

```
angular/angular (954.30KB)
  shift: 129.39ms
  esprima: 63.94ms
  babel: 147.85ms
  traceur: 85.51ms
esprima/esprima (173.34KB)
  shift: 42.85ms
  esprima: 22.26ms
  babel: 51.38ms
  traceur: 31.95ms
./dist/parser (381.39KB)
  shift: 34.03ms
  esprima: 18.30ms
  babel: 50.09ms
  traceur: 27.40ms
```

Merging immediately.
