### PR TITLE
fixes #185: ClassHeritage is strict mode code

### DIFF
--- a/dist/early-errors.js
+++ b/dist/early-errors.js
@@ -267,6 +267,7 @@ var EarlyErrorChecker = (function (_MonoidalReducer) {
       var sElements = this.fold(elements);
       sElements = sElements.enforceStrictErrors();
       if (node["super"] != null) {
+        _super = _super.enforceStrictErrors();
         s = this.append(s, _super);
         sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
       }
@@ -300,6 +301,7 @@ var EarlyErrorChecker = (function (_MonoidalReducer) {
       var sElements = this.fold(elements);
       sElements = sElements.enforceStrictErrors();
       if (node["super"] != null) {
+        _super = _super.enforceStrictErrors();
         s = this.append(s, _super);
         sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
       }

--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -184,6 +184,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {
+      _super = _super.enforceStrictErrors();
       s = this.append(s, _super);
       sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
     }
@@ -211,6 +212,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {
+      _super = _super.enforceStrictErrors();
       s = this.append(s, _super);
       sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
     }

--- a/test/declaration/generator-declaration.js
+++ b/test/declaration/generator-declaration.js
@@ -131,14 +131,6 @@ suite("Parser", function () {
         expression: { type: "LiteralNumericExpression", value: 0 }
       });
 
-    testParse("function *a(a=class extends yield{}){}", function (p) {
-      return p.body.statements[0].params.items[0].init.super;
-    }, { type: "IdentifierExpression", name: "yield" });
-    testParse("function *a({[class extends yield{}]:a}){}", function (p) {
-      return p.body.statements[0].params.items[0].properties[0].name.expression.super;
-    }, { type: "IdentifierExpression", name: "yield" });
-
-
     testParse("function* a() {} function a() {}", id,
       {
         type: "Script",

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -147,6 +147,8 @@ suite("Parser", function () {
     testEarlyError("class A { f(eval){} };", "The identifier \"eval\" must not be in binding position in strict mode");
     testEarlyError("class A { *f(eval){} };", "The identifier \"eval\" must not be in binding position in strict mode");
     testEarlyError("class A { set f(eval){} };", "The identifier \"eval\" must not be in binding position in strict mode");
+    testEarlyError("class A extends (eval = null) { };", "The identifier \"eval\" must not be in binding position in strict mode");
+    testEarlyError("!class extends (eval = null) { };", "The identifier \"eval\" must not be in binding position in strict mode");
     // It is a Syntax Error if the code matched by this production is contained in strict code.
     testEarlyError("'use strict'; +yield;", "The identifier \"yield\" must not be in expression position in strict mode");
     testEarlyError("'use strict'; yield:;", "The identifier \"yield\" must not be in label position in strict mode");


### PR DESCRIPTION
Fixes #185. For some reason, babel has changed and breaks code coverage.
