### PR TITLE
fixes #192: don't collect exported bindings in `export ... from ...`

### DIFF
--- a/dist/early-error-state.js
+++ b/dist/early-error-state.js
@@ -376,6 +376,12 @@ var EarlyErrorState = (function () {
       return this;
     }
   }, {
+    key: "clearExportedBindings",
+    value: function clearExportedBindings() {
+      this.exportedBindings = new MultiMap();
+      return this;
+    }
+  }, {
     key: "addError",
     value: function addError(e) {
       this.errors.push(e);

--- a/dist/early-errors.js
+++ b/dist/early-errors.js
@@ -346,6 +346,15 @@ var EarlyErrorChecker = (function (_MonoidalReducer) {
       return s;
     }
   }, {
+    key: "reduceExportFrom",
+    value: function reduceExportFrom(node) {
+      var s = _get(Object.getPrototypeOf(EarlyErrorChecker.prototype), "reduceExportFrom", this).apply(this, arguments);
+      if (node.moduleSpecifier != null) {
+        s = s.clearExportedBindings();
+      }
+      return s;
+    }
+  }, {
     key: "reduceExportSpecifier",
     value: function reduceExportSpecifier(node) {
       var s = _get(Object.getPrototypeOf(EarlyErrorChecker.prototype), "reduceExportSpecifier", this).apply(this, arguments);

--- a/src/early-error-state.js
+++ b/src/early-error-state.js
@@ -306,6 +306,11 @@ export class EarlyErrorState {
     return this;
   }
 
+  clearExportedBindings() {
+    this.exportedBindings = new MultiMap;
+    return this;
+  }
+
 
   addError(e) {
     this.errors.push(e);

--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -255,6 +255,14 @@ export class EarlyErrorChecker extends MonoidalReducer {
     return s;
   }
 
+  reduceExportFrom(node) {
+    let s = super.reduceExportFrom(...arguments);
+    if (node.moduleSpecifier != null) {
+      s = s.clearExportedBindings();
+    }
+    return s;
+  }
+
   reduceExportSpecifier(node) {
     let s = super.reduceExportSpecifier(...arguments);
     s = s.exportName(node.exportedName, node);

--- a/test/modules/export.js
+++ b/test/modules/export.js
@@ -36,25 +36,25 @@ function testExportDecl(code, tree) {
 suite("Parser", function () {
   suite("export declaration", function () {
 
-    testExportDecl("export * from \"a\"; var a;", { type: "ExportAllFrom", moduleSpecifier: "a" });
+    testExportDecl("export * from \"a\"", { type: "ExportAllFrom", moduleSpecifier: "a" });
 
-    testExportDecl("export * from \"a\"; var a;", { type: "ExportAllFrom", moduleSpecifier: "a" });
+    testExportDecl("export * from \"a\"", { type: "ExportAllFrom", moduleSpecifier: "a" });
 
-    testExportDecl("export {} from \"a\"; var a;", { type: "ExportFrom", namedExports: [], moduleSpecifier: "a" });
+    testExportDecl("export {} from \"a\"", { type: "ExportFrom", namedExports: [], moduleSpecifier: "a" });
 
-    testExportDecl("export {a} from \"a\"; var a;", {
+    testExportDecl("export {a} from \"a\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: null, exportedName: "a" }],
       moduleSpecifier: "a"
     });
 
-    testExportDecl("export {a,} from \"a\"; var a;", {
+    testExportDecl("export {a,} from \"a\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: null, exportedName: "a" }],
       moduleSpecifier: "a"
     });
 
-    testExportDecl("export {a,b} from \"a\"; var a,b;", {
+    testExportDecl("export {a,b} from \"a\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: null, exportedName: "a" }, {
         type: "ExportSpecifier",
@@ -64,22 +64,28 @@ suite("Parser", function () {
       moduleSpecifier: "a"
     });
 
-    testExportDecl("export {a as b} from \"a\"; var a;", {
+    testExportDecl("export {a as b} from \"a\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: "a", exportedName: "b" }],
       moduleSpecifier: "a"
     });
 
-    testExportDecl("export {as as as} from \"as\"; var as;", {
+    testExportDecl("export {as as as} from \"as\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: "as", exportedName: "as" }],
       moduleSpecifier: "as"
     });
 
-    testExportDecl("export {as as function} from \"as\"; var as;", {
+    testExportDecl("export {as as function} from \"as\"", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: "as", exportedName: "function" }],
       moduleSpecifier: "as"
+    });
+
+    testExportDecl("export {a} from \"m\"", {
+      type: "ExportFrom",
+      namedExports: [ { type: "ExportSpecifier", name: null, exportedName: "a" } ],
+      moduleSpecifier: "m"
     });
 
     testExportDecl("export {a}\n var a;", {


### PR DESCRIPTION
Fixes #192.
