### PR TITLE
fixes #191: ExportSpecifier should accept all IdentifierNames

### DIFF
--- a/dist/parser.js
+++ b/dist/parser.js
@@ -423,7 +423,7 @@ var Parser = (function (_Tokenizer) {
     key: "parseExportSpecifier",
     value: function parseExportSpecifier() {
       var startLocation = this.getLocation();
-      var name = this.parseIdentifier();
+      var name = this.parseIdentifierName();
       if (this.eatContextualKeyword("as")) {
         var exportedName = this.parseIdentifierName();
         return this.markLocation({ type: "ExportSpecifier", name: name, exportedName: exportedName }, startLocation);

--- a/src/parser.js
+++ b/src/parser.js
@@ -383,7 +383,7 @@ export class Parser extends Tokenizer {
 
   parseExportSpecifier() {
     let startLocation = this.getLocation();
-    let name = this.parseIdentifier();
+    let name = this.parseIdentifierName();
     if (this.eatContextualKeyword("as")) {
       let exportedName = this.parseIdentifierName();
       return this.markLocation({ type: "ExportSpecifier", name, exportedName }, startLocation);

--- a/test/modules/export.js
+++ b/test/modules/export.js
@@ -88,6 +88,12 @@ suite("Parser", function () {
       moduleSpecifier: "m"
     });
 
+    testExportDecl("export {if as var} from \"a\";", {
+      type: "ExportFrom",
+      namedExports: [{ type: "ExportSpecifier", name: "if", exportedName: "var" }],
+      moduleSpecifier: "a"
+    });
+
     testExportDecl("export {a}\n var a;", {
       type: "ExportFrom",
       namedExports: [{ type: "ExportSpecifier", name: null, exportedName: "a" }],
@@ -287,8 +293,6 @@ suite("Parser", function () {
     testParseModuleFailure("export {a,b} from a", "Unexpected identifier");
     testParseModuleFailure("export {a as} from a", "Unexpected token \"}\"");
     testParseModuleFailure("export {as b} from a", "Unexpected identifier");
-    testParseModuleFailure("export {function} from a", "Unexpected token \"function\"");
-    testParseModuleFailure("export {function as a} from a", "Unexpected token \"function\"");
     testParseModuleFailure("export * from a", "Unexpected identifier");
     testParseModuleFailure("export / from a", "Unexpected token \"/\"");
     testParseModuleFailure("export * From \"a\"", "Unexpected identifier");


### PR DESCRIPTION
Fixes #191. Depends on #195.
