### PR TITLE
fixes #201: disallow unicode escaped surrogate pairs in identifiers

### DIFF
--- a/dist/tokenizer.js
+++ b/dist/tokenizer.js
@@ -737,24 +737,6 @@ var Tokenizer = (function () {
           if (code < 0) {
             throw this.createILLEGAL();
           }
-          if (55296 <= code && code <= 56319) {
-            if (this.source.charAt(this.index) !== "\\") {
-              throw this.createILLEGAL();
-            }
-            ++this.index;
-            if (this.index >= this.source.length) {
-              throw this.createILLEGAL();
-            }
-            if (this.source.charAt(this.index) !== "u") {
-              throw this.createILLEGAL();
-            }
-            ++this.index;
-            var lowSurrogateCode = this.scanUnicode();
-            if (!(56320 <= lowSurrogateCode && lowSurrogateCode <= 57343)) {
-              throw this.createILLEGAL();
-            }
-            code = decodeUtf16(code, lowSurrogateCode);
-          }
           ch = fromCodePoint(code);
         } else if (55296 <= code && code <= 56319) {
           if (this.index >= this.source.length) {

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -717,24 +717,6 @@ export default class Tokenizer {
         if (code < 0) {
           throw this.createILLEGAL();
         }
-        if (0xD800 <= code && code <= 0xDBFF) {
-          if (this.source.charAt(this.index) !== "\\") {
-            throw this.createILLEGAL();
-          }
-          ++this.index;
-          if (this.index >= this.source.length) {
-            throw this.createILLEGAL();
-          }
-          if (this.source.charAt(this.index) !== "u") {
-            throw this.createILLEGAL();
-          }
-          ++this.index;
-          let lowSurrogateCode = this.scanUnicode();
-          if (!(0xDC00 <= lowSurrogateCode && lowSurrogateCode <= 0xDFFF)) {
-            throw this.createILLEGAL();
-          }
-          code = decodeUtf16(code, lowSurrogateCode);
-        }
         ch = fromCodePoint(code);
       } else if (0xD800 <= code && code <= 0xDBFF) {
         if (this.index >= this.source.length) {

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -278,7 +278,6 @@ suite("Parser", function () {
     testEarlyError("let \\u0061, \\u{0061};", "Duplicate binding \"a\"");
     testEarlyError("let x\\u{61}, x\\u{0061};", "Duplicate binding \"xa\"");
     testEarlyError("let x\\u{E01D5}, x\uDB40\uDDD5;", "Duplicate binding \"x\uDB40\uDDD5\"");
-    testEarlyError("let x\\u{E01D5}, x\\uDB40\\uDDD5;", "Duplicate binding \"x\uDB40\uDDD5\"");
     testEarlyError("for(let a, a;;);", "Duplicate binding \"a\"");
     testEarlyError("for(let [a, a];;);", "Duplicate binding \"a\"");
     testEarlyError("for(const a = 0, a = 1;;);", "Duplicate binding \"a\"");

--- a/test/expressions/identifier-expression.js
+++ b/test/expressions/identifier-expression.js
@@ -110,10 +110,6 @@ suite("Parser", function () {
         { type: "IdentifierExpression", name: "\uD800\uDC00" }
       );
 
-      testParse("\\uD800\\uDC00", expr,
-        { type: "IdentifierExpression", name: "\uD800\uDC00" }
-      );
-
       testParse("T\u203F", expr,
         { type: "IdentifierExpression", name: "T\u203F" }
       );
@@ -133,6 +129,8 @@ suite("Parser", function () {
       testParse("\u2163\u2161\u200A", expr,
         { type: "IdentifierExpression", name: "\u2163\u2161" }
       );
+
+      testParseFailure("\\uD800\\uDC00", "Unexpected \"\\\\\"");
 
     });
 

--- a/test/failure.js
+++ b/test/failure.js
@@ -46,9 +46,9 @@ suite("Parser", function () {
     testParseFailure("a\\u113", "Unexpected \"1\"");
     testParseFailure("\\uD800", "Unexpected end of input");
     testParseFailure("\\uD800x", "Unexpected \"x\"");
-    testParseFailure("\\uD800\\", "Unexpected end of input");
-    testParseFailure("\\uD800\\u", "Unexpected end of input");
-    testParseFailure("\\uD800\\x62", "Unexpected \"x\"");
+    testParseFailure("\\uD800\\", "Unexpected \"\\\\\"");
+    testParseFailure("\\uD800\\u", "Unexpected \"\\\\\"");
+    testParseFailure("\\uD800\\x62", "Unexpected \"\\\\\"");
     testParseFailure("\uD800", "Unexpected end of input");
     testParseFailure("\uD800x", "Unexpected end of input");
     testParseFailure("\uD800\\", "Unexpected end of input");

--- a/test/statements/variable-declaration-statement.js
+++ b/test/statements/variable-declaration-statement.js
@@ -267,20 +267,6 @@ suite("Parser", function () {
         }
       }
     );
-    testParse("let x, x\\uDB40\\uDDD5;", stmt,
-      {
-        type: "VariableDeclarationStatement",
-        declaration: {
-          type: "VariableDeclaration",
-          kind: "let",
-          declarators: [{
-            type: "VariableDeclarator",
-            binding: { type: "BindingIdentifier", name: "x" },
-            init: null
-          }, { type: "VariableDeclarator", binding: { type: "BindingIdentifier", name: "x\uDB40\uDDD5" }, init: null }]
-        }
-      }
-    );
     testParse("let x, x\uDB40\uDDD5;", stmt,
       {
         type: "VariableDeclarationStatement",


### PR DESCRIPTION
Fixes #201.
