### PR TITLE
fixes #212: fixes lookaheadAssignmentExpression

### DIFF
--- a/dist/parser.js
+++ b/dist/parser.js
@@ -1208,6 +1208,7 @@ var Parser = (function (_Tokenizer) {
         case _tokenizer.TokenType.FALSE:
         case _tokenizer.TokenType.FUNCTION:
         case _tokenizer.TokenType.IDENTIFIER:
+        case _tokenizer.TokenType.INC:
         case _tokenizer.TokenType.LET:
         case _tokenizer.TokenType.LBRACE:
         case _tokenizer.TokenType.LBRACK:
@@ -1236,12 +1237,10 @@ var Parser = (function (_Tokenizer) {
         return this.markLocation({ type: "YieldExpression", expression: null }, startLocation);
       }
       var isGenerator = !!this.eat(_tokenizer.TokenType.MUL);
-      var previousYield = this.allowYieldExpression;
       var expr = null;
       if (isGenerator || this.lookaheadAssignmentExpression()) {
         expr = this.parseAssignmentExpression();
       }
-      this.allowYieldExpression = previousYield;
       var type = isGenerator ? "YieldGeneratorExpression" : "YieldExpression";
       return this.markLocation({ type: type, expression: expr }, startLocation);
     }

--- a/src/parser.js
+++ b/src/parser.js
@@ -1135,6 +1135,7 @@ export class Parser extends Tokenizer {
       case TokenType.FALSE:
       case TokenType.FUNCTION:
       case TokenType.IDENTIFIER:
+      case TokenType.INC:
       case TokenType.LET:
       case TokenType.LBRACE:
       case TokenType.LBRACK:
@@ -1162,12 +1163,10 @@ export class Parser extends Tokenizer {
       return this.markLocation({ type: "YieldExpression", expression: null }, startLocation);
     }
     let isGenerator = !!this.eat(TokenType.MUL);
-    let previousYield = this.allowYieldExpression;
     let expr = null;
     if (isGenerator || this.lookaheadAssignmentExpression()) {
       expr = this.parseAssignmentExpression();
     }
-    this.allowYieldExpression = previousYield;
     let type = isGenerator ? "YieldGeneratorExpression" : "YieldExpression";
     return this.markLocation({type, expression: expr}, startLocation);
   }

--- a/test/expressions/yield-expression.js
+++ b/test/expressions/yield-expression.js
@@ -69,6 +69,13 @@ suite("Parser", function () {
     testParse("function *a(){yield/a/}", yde, { type: "LiteralRegExpExpression", pattern: "a", flags: "" });
     testParse("function *a(){yield/=3/}", yde, { type: "LiteralRegExpExpression", pattern: "=3", flags: "" });
     testParse("function *a(){yield class{}}", yde, { type: "ClassExpression", name: null, super: null, elements: [] });
-
+    testParse("function *a(){yield ++a;}", yde, {
+      type: "PrefixExpression",
+      operand: { type: "IdentifierExpression", name: "a" },
+      operator: "++" });
+    testParse("function *a(){yield --a;}", yde, {
+      type: "PrefixExpression",
+      operand: { type: "IdentifierExpression", name: "a" },
+      operator: "--" });
   });
 });


### PR DESCRIPTION
Closes #212: `yield ++y;` will cause `Unexpected token "++"`

Fixes `lookaheadAssignmentExpression`.
