### PR TITLE
Fixes #206: Invalid for loop throws internal error

### DIFF
--- a/dist/parser.js
+++ b/dist/parser.js
@@ -1252,6 +1252,7 @@ var Parser = (function (_Tokenizer) {
       var test = this.parseBinaryExpression();
       if (this.firstExprError) return test;
       if (this.eat(_tokenizer.TokenType.CONDITIONAL)) {
+        this.isBindingElement = this.isAssignmentTarget = false;
         var previousAllowIn = this.allowIn;
         this.allowIn = true;
         var consequent = this.isolateCoverGrammar(this.parseAssignmentExpression);

--- a/src/parser.js
+++ b/src/parser.js
@@ -1177,6 +1177,7 @@ export class Parser extends Tokenizer {
     let test = this.parseBinaryExpression();
     if (this.firstExprError) return test;
     if (this.eat(TokenType.CONDITIONAL)) {
+      this.isBindingElement = this.isAssignmentTarget = false;
       let previousAllowIn = this.allowIn;
       this.allowIn = true;
       let consequent = this.isolateCoverGrammar(this.parseAssignmentExpression);

--- a/test/statements/for-in-statement.js
+++ b/test/statements/for-in-statement.js
@@ -136,6 +136,6 @@ suite("Parser", function () {
 
     testParseFailure("for(let a = 0 in b);", "Invalid variable declaration in for-in statement");
     testParseFailure("for(const a = 0 in b);", "Invalid variable declaration in for-in statement");
-
+    testParseFailure("for(let ? b : c in 0);", "Invalid left-hand side in for-in");
   });
 });


### PR DESCRIPTION
Properly set flags in `parseConditionalExpression`.

Closes #206: Invalid for loop throws internal error.
