### PR TITLE
fixes #247: disallow legacy octal escapes in strict mode

### DIFF
--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1194,6 +1194,7 @@ export default class Tokenizer {
           break;
         default:
           if ("0" <= ch && ch <= "7") {
+            let octalStart = this.index;
             let octLen = 1;
             // 3 digits are only allowed when string starts
             // with 0, 1, 2, 3
@@ -1202,13 +1203,13 @@ export default class Tokenizer {
             }
             let code = 0;
             while (octLen < 3 && "0" <= ch && ch <= "7") {
+              this.index++;
               if (octLen > 0 || ch !== "0") {
-                octal = true;
+                octal = this.source.slice(octalStart, this.index);
               }
               code *= 8;
-              octLen++;
               code += ch - "0";
-              this.index++;
+              octLen++;
               if (this.index === this.source.length) {
                 throw this.createILLEGAL();
               }
@@ -1243,7 +1244,7 @@ export default class Tokenizer {
     let start = this.index;
     this.index++;
 
-    let octal = false;
+    let octal = null;
     while (this.index < this.source.length) {
       let ch = this.source.charAt(this.index);
       if (ch === quote) {
@@ -1281,8 +1282,8 @@ export default class Tokenizer {
           break;
         case 0x5C:  // \\
         {
-          let octal = this.scanStringEscape("", false)[1];
-          if (octal) {
+          let octal = this.scanStringEscape("", null)[1];
+          if (octal != null) {
             throw this.createILLEGAL();
           }
           break;

--- a/test/expressions/literals/literal-string-expression.js
+++ b/test/expressions/literals/literal-string-expression.js
@@ -32,7 +32,7 @@ suite("Parser", function () {
     testParse("('\u202a')", expr, { type: "LiteralStringExpression", value: "\u202A" });
     testParse("('\\0')", expr, { type: "LiteralStringExpression", value: "\0" });
     testParse("'use strict'; ('\\0')", expr, { type: "LiteralStringExpression", value: "\0" });
-    testParse("'use strict'; ('\\0x')", expr, { type: "LiteralStringExpression", value: "\0x" });
+    testParse("'use strict'; ('\\0x')", expr, { type: "LiteralStringExpression", value: "\0" + "x" });
     testParse("('\\01')", expr, { type: "LiteralStringExpression", value: "\x01" });
     testParse("('\\1')", expr, { type: "LiteralStringExpression", value: "\x01" });
     testParse("('\\11')", expr, { type: "LiteralStringExpression", value: "\t" });
@@ -49,6 +49,8 @@ suite("Parser", function () {
     testParse("('\\u{10FFFF}')", expr, { type: "LiteralStringExpression", value: "\uDBFF\uDFFF" });
     testParse("('\\u{0000000000F8}')", expr, { type: "LiteralStringExpression", value: "\xF8" });
 
+    testParseFailure("'", "Unexpected end of input");
+    testParseFailure("\"", "Unexpected end of input");
     testParseFailure("(')", "Unexpected end of input");
     testParseFailure("('\n')", "Unexpected \"\\n\"");
     testParseFailure("('\\x')", "Unexpected \"'\"");
@@ -59,6 +61,15 @@ suite("Parser", function () {
     testParseFailure("('\u2028')", "Unexpected \"\u2028\"");
     testParseFailure("('\u2029')", "Unexpected \"\u2029\"");
     testParseFailure("('\\u{2028')", "Unexpected \"{\"");
+    testParseFailure("'use strict'; ('\\1')", "Unexpected legacy octal escape sequence: \\1");
+    testParseFailure("'use strict'; ('\\4')", "Unexpected legacy octal escape sequence: \\4");
+    testParseFailure("'use strict'; ('\\11')", "Unexpected legacy octal escape sequence: \\11");
+    testParseFailure("'use strict'; ('\\41')", "Unexpected legacy octal escape sequence: \\41");
+    testParseFailure("'use strict'; ('\\01')", "Unexpected legacy octal escape sequence: \\01");
+    testParseFailure("'use strict'; ('\\00')", "Unexpected legacy octal escape sequence: \\00");
+    testParseFailure("'use strict'; ('\\001')", "Unexpected legacy octal escape sequence: \\001");
+    testParseFailure("'use strict'; ('\\000')", "Unexpected legacy octal escape sequence: \\000");
+    testParseFailure("'use strict'; ('\\123')", "Unexpected legacy octal escape sequence: \\123");
 
     // early grammar error: 11.8.4.1
     // It is a Syntax Error if the MV of HexDigits > 1114111.


### PR DESCRIPTION
Fixes #247.
