### PR TITLE
fixes #245: prohibit legacy octal integer literals in strict mode

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1544,6 +1544,13 @@ export class Parser extends Tokenizer {
   parseNumericLiteral() {
     let startLocation = this.getLocation();
     let token = this.lex();
+    if (token.octal && this.strict) {
+      if (token.noctal) {
+        throw this.createErrorWithLocation(startLocation, "Unexpected noctal integer literal");
+      } else {
+        throw this.createErrorWithLocation(startLocation, "Unexpected legacy octal integer literal");
+      }
+    }
     let node = token.value === 1 / 0
       ? { type: "LiteralInfinityExpression" }
       : { type: "LiteralNumericExpression", value: token.value };

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -968,6 +968,7 @@ export default class Tokenizer {
       value: parseInt(this.getSlice(start, startLocation).text.substr(offset), 2),
       slice: this.getSlice(start, startLocation),
       octal: false,
+      noctal: false,
     };
   }
 
@@ -992,6 +993,7 @@ export default class Tokenizer {
       value: parseInt(this.getSlice(start, startLocation).text.substr(2), 8),
       slice: this.getSlice(start, startLocation),
       octal: false,
+      noctal: false,
     };
   }
 
@@ -1017,6 +1019,7 @@ export default class Tokenizer {
       slice: this.getSlice(start, startLocation),
       value: parseInt(this.getSlice(start, startLocation).text.substr(1), isOctal ? 8 : 10),
       octal: true,
+      noctal: !isOctal,
     };
   }
 
@@ -1049,6 +1052,7 @@ export default class Tokenizer {
           value: +slice.text,
           slice,
           octal: false,
+          noctal: false,
         };
       }
     } else if (ch !== ".") {
@@ -1063,6 +1067,7 @@ export default class Tokenizer {
             value: +slice.text,
             slice,
             octal: false,
+            noctal: false,
           };
         }
         ch = this.source.charAt(this.index);
@@ -1079,6 +1084,7 @@ export default class Tokenizer {
           value: +slice.text,
           slice,
           octal: false,
+          noctal: false,
         };
       }
 
@@ -1093,6 +1099,7 @@ export default class Tokenizer {
             value: +slice.text,
             slice,
             octal: false,
+            noctal: false,
           };
         }
         ch = this.source.charAt(this.index);
@@ -1144,6 +1151,7 @@ export default class Tokenizer {
       value: +slice.text,
       slice,
       octal: false,
+      noctal: false,
     };
   }
 

--- a/test/expressions/literals/literal-numeric-expression.js
+++ b/test/expressions/literals/literal-numeric-expression.js
@@ -70,6 +70,12 @@ suite("Parser", function () {
     testParseFailure("0B9", "Unexpected \"9\"");
     testParseFailure("0B18", "Unexpected \"8\"");
     testParseFailure("0B12", "Unexpected \"2\"");
+    testParseFailure("'use strict'; 01", "Unexpected legacy octal integer literal");
+    testParseFailure("'use strict'; 0123", "Unexpected legacy octal integer literal");
+    testParseFailure("'use strict'; 00", "Unexpected legacy octal integer literal");
+    testParseFailure("'use strict'; 07", "Unexpected legacy octal integer literal");
+    testParseFailure("'use strict'; 08", "Unexpected noctal integer literal");
+    testParseFailure("'use strict'; 019", "Unexpected noctal integer literal");
 
     // Octal Numeric Literal
     testParse("0o0", expr, { type: "LiteralNumericExpression", value: 0 });


### PR DESCRIPTION
Fixes #245.
