### PR TITLE
fixes #227: array destructuring rest element erroneously allows default

### DIFF
--- a/test/destructuring/assignment/array-binding.js
+++ b/test/destructuring/assignment/array-binding.js
@@ -289,11 +289,10 @@ suite("Parser", function () {
       testParseFailure("[...0,...{a=0}]=0", "Illegal property initializer");
       testParseFailure("[...{a=0},]", "Illegal property initializer");
       testParseFailure("[...{a=0},]=0", "Invalid left-hand side in assignment");
-
-      // new tests
       testParseFailure("[0] = 0", "Invalid left-hand side in assignment");
       testParseFailure("[a, ...b, {c=0}]", "Illegal property initializer");
       testParseFailure("{a = [...b, c]} = 0", "Unexpected token \"=\"");
+      testParseFailure("[a, ...(b = c)] = 0", "Invalid left-hand side in assignment");
     });
   });
 });


### PR DESCRIPTION
Fixes #227. Stole `transformDestructuringWithDefault` strategy from shift-java.
