### PR TITLE
fixes #259: disallow yield binding in object destructuring in generators

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -2081,6 +2081,8 @@ export class Parser extends Tokenizer {
           let expr = this.parseAssignmentExpression();
           defaultValue = expr;
           this.allowYieldExpression = previousAllowYieldExpression;
+        } else if (token.type === TokenType.YIELD && this.allowYieldExpression) {
+          throw this.createUnexpected(token);
         }
         return this.markLocation({
           type: "BindingPropertyIdentifier",

--- a/test/declaration/generator-declaration.js
+++ b/test/declaration/generator-declaration.js
@@ -135,6 +135,10 @@ suite("Parser", function () {
 
     testParseFailure("label: function* a(){}", "Unexpected token \"*\"");
     testParseFailure("function*g(yield){}", "Unexpected token \"yield\"");
+    testParseFailure("function*g({yield}){}", "Unexpected token \"yield\"");
+    testParseFailure("function*g([yield]){}", "Unexpected token \"yield\"");
+    testParseFailure("function*g({a: yield}){}", "Unexpected token \"yield\"");
+    testParseFailure("function*g(yield = 0){}", "Unexpected token \"yield\"");
     testParseFailure("function*g(){ var yield; }", "Unexpected token \"yield\"");
     testParseFailure("function*g(){ var yield = 1; }", "Unexpected token \"yield\"");
     testParseFailure("function*g(){ function yield(){}; }", "Unexpected token \"yield\"");


### PR DESCRIPTION
Fixes #259.
