### PR TITLE
`for({a=0} in 0);` now parses, fixes #267

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -669,6 +669,10 @@ export class Parser extends Tokenizer {
         this.allowIn = previousAllowIn;
 
         if (this.isAssignmentTarget && expr.type !== "AssignmentExpression" && (this.match(TokenType.IN) || this.matchContextualKeyword("of"))) {
+          if (expr.type === "ObjectExpression") {
+            this.firstExprError = null;
+          }
+
           if (startsWithLet && this.matchContextualKeyword("of")) {
             throw this.createError(ErrorMessages.INVALID_LHS_IN_FOR_OF);
           }

--- a/test/statements/for-in-statement.js
+++ b/test/statements/for-in-statement.js
@@ -134,6 +134,19 @@ suite("Parser", function () {
       body: { type: "EmptyStatement" }
     });
 
+    testParse("for({a=0} in b);", stmt, {
+      type: "ForInStatement",
+      left: {
+        type: "ObjectBinding",
+        properties: [{
+          type: "BindingPropertyIdentifier",
+          binding: { type: "BindingIdentifier", name: "a" },
+          init: { type: "LiteralNumericExpression", value: 0 } }]
+      },
+      right: { type: "IdentifierExpression", name: "b" },
+      body: { type: "EmptyStatement" }
+    });
+
     testParseFailure("for(let a = 0 in b);", "Invalid variable declaration in for-in statement");
     testParseFailure("for(const a = 0 in b);", "Invalid variable declaration in for-in statement");
     testParseFailure("for(let ? b : c in 0);", "Invalid left-hand side in for-in");

--- a/test/statements/for-of-statement.js
+++ b/test/statements/for-of-statement.js
@@ -117,6 +117,19 @@ suite("Parser", function () {
       }
     );
 
+    testParse("for({a=0} of b);", stmt, {
+      type: "ForOfStatement",
+      left: {
+        type: "ObjectBinding",
+        properties: [{
+          type: "BindingPropertyIdentifier",
+          binding: { type: "BindingIdentifier", name: "a" },
+          init: { type: "LiteralNumericExpression", value: 0 } }]
+      },
+      right: { type: "IdentifierExpression", name: "b" },
+      body: { type: "EmptyStatement" }
+    });
+
     testParseFailure("for(let of 0);", "Unexpected number");
     testParseFailure("for(this of 0);", "Invalid left-hand side in for-of");
 


### PR DESCRIPTION
fixes #267 
