### PR TITLE
Mark compound assignments as not binding elements

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1066,12 +1066,15 @@ export class Parser extends Tokenizer {
     let rhs = this.parseAssignmentExpression();
 
     this.firstExprError = null;
-    return this.markLocation(
-      operator.type === TokenType.ASSIGN
-        ? { type: "AssignmentExpression", binding: expr, expression: rhs }
-        : { type: "CompoundAssignmentExpression", binding: expr, operator: operator.type.name, expression: rhs }
-    , startLocation
-    );
+    let node;
+    if (operator.type === TokenType.ASSIGN) {
+      node = { type: "AssignmentExpression", binding: expr, expression: rhs };
+    }
+    else {
+      node = { type: "CompoundAssignmentExpression", binding: expr, operator: operator.type.name, expression: rhs };
+      this.isBindingElement = this.isAssignmentTarget = false;
+    }
+    return this.markLocation(node, startLocation);
   }
 
   transformDestructuring(node) {

--- a/test/expressions/update-expression.js
+++ b/test/expressions/update-expression.js
@@ -77,5 +77,7 @@ suite("Parser", function () {
         operator: "--" }
     );
 
+    testParseFailure("({a: (b = 0)} = {})", "Invalid left-hand side in assignment");
+    testParseFailure("([(a = b)] = []", "Invalid left-hand side in assignment");
   });
 });

--- a/test/miscellaneous/interactions.js
+++ b/test/miscellaneous/interactions.js
@@ -637,5 +637,19 @@ suite("Parser", function () {
       }
     );
 
+    // CompoundAssignmentExpressions are not valid binding targets
+    testParse("null && (x += null)", expr,
+      { type: "BinaryExpression",
+        operator: "&&",
+        left: { type: "LiteralNullExpression" },
+        right: {
+          type: "CompoundAssignmentExpression",
+          operator: "+=",
+          binding: { type: "BindingIdentifier", name: "x" },
+          expression: { type: "LiteralNullExpression" } } }
+    );
+
+    testParseFailure("({a: b += 0} = {})", "Invalid left-hand side in assignment");
+    testParseFailure("[a += b] = []", "Invalid left-hand side in assignment");
   });
 });


### PR DESCRIPTION
Fixes #189 and #255.

Note that the two additional tests in `update-expression.js` were actually fixed by a30696c, but they're added here as part of closing #189.

As this PR closes all remaining known bugs except #130 and #168, it's probably time for a patch version bump + publish.
