### PR TITLE
Correct assignment of ExportName

### DIFF
--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -277,15 +277,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
   reduceExportDefault(node) {
     let s = super.reduceExportDefault(...arguments);
     s = s.functionDeclarationNamesAreLexical();
-    switch (node.body.type) {
-      case "FunctionDeclaration":
-      case "ClassDeclaration":
-        if (node.body.name.name !== "*default*") {
-          s = s.exportDeclaredNames();
-        }
-        break;
-    }
-    s = s.exportName("*default*", node);
+    s = s.exportName("default", node);
     return s;
   }
 
@@ -546,7 +538,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
       }
     });
     s.exportedBindings.forEachEntry((nodes, bindingName) => {
-      if (bindingName !== "*default*" && !s.lexicallyDeclaredNames.has(bindingName) && !s.varDeclaredNames.has(bindingName)) {
+      if (!s.lexicallyDeclaredNames.has(bindingName) && !s.varDeclaredNames.has(bindingName)) {
         nodes.forEach(undeclaredNode => {
           s = s.addError(new EarlyError(undeclaredNode, `Exported binding ${JSON.stringify(bindingName)} is not declared`));
         });

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -704,9 +704,12 @@ suite("Parser", function () {
     testModuleEarlyError("export let a; export {a};", "Duplicate export \"a\"");
     testModuleEarlyError("export {a}; export const a = 0;", "Duplicate export \"a\"");
     testModuleEarlyError("export let a; let b; export {b as a};", "Duplicate export \"a\"");
-    testModuleEarlyError("export default 0; export default 0;", "Duplicate export \"*default*\"");
-    testModuleEarlyError("export default 0; export default function f(){};", "Duplicate export \"*default*\"");
-    testModuleEarlyError("export default 0; export default class a {};", "Duplicate export \"*default*\"");
+    testModuleEarlyError("export default 0; export default 0;", "Duplicate export \"default\"");
+    testModuleEarlyError("export default 0; export default function f(){};", "Duplicate export \"default\"");
+    testModuleEarlyError("export default 0; export default class a {};", "Duplicate export \"default\"");
+    testModuleEarlyError("var x; export default function() {} export { x as default };", "Duplicate export \"default\"");
+    testModuleEarlyError("var x; export default class {} export { x as default };", "Duplicate export \"default\"");
+    testModuleEarlyError("var x, y; export default x; export { y as default };", "Duplicate export \"default\"");
     // It is a Syntax Error if any element of the ExportedBindings of ModuleItemList does not also occur in either the VarDeclaredNames of ModuleItemList, or the LexicallyDeclaredNames of ModuleItemList.
     testModuleEarlyError("export {a};", "Exported binding \"a\" is not declared");
     testModuleEarlyError("export {b as a};", "Exported binding \"b\" is not declared");


### PR DESCRIPTION
The string "*default*" is only assigned to the [[LocalName]] field of
ExportEntry records. By incorrectly using that string as a synthetic
value for [[ExportName]], the parser cannot detect cases where an export
which is explicitly named "default" collides with a default export as
specified via `export default`.

Update the parser to correctly assign the value "default" to
[[ExportName]] in these cases. Remove unnecessary logic concerning each
entry's [[LocalName]] value.

> 15.2.3.5 Static Semantics: ExportEntries
> 
> [...]
> 
> ExportDeclaration : export default HoistableDeclaration
> 
> ```
> 1. Let names be BoundNames of HoistableDeclaration.
> 2. Let localName be the sole element of names.
> 3. Return a new List containing the Record {[[ModuleRequest]]:
>    null, [[ImportName]]: null, [[LocalName]]: localName,
>    [[ExportName]]: "default"}.
> ```
> 
> ExportDeclaration : export default ClassDeclaration
> 
> ```
> 1. Let names be BoundNames of ClassDeclaration.
> 2. Let localName be the sole element of names.
> 3. Return a new List containing the Record {[[ModuleRequest]]:
>    null, [[ImportName]]: null, [[LocalName]]: localName,
>    [[ExportName]]: "default"}.
> ```
> 
> ExportDeclaration : export default AssignmentExpression;
> 
> ```
> 1. Let entry be the Record {[[ModuleRequest]]: null,
>    [[ImportName]]: null, [[LocalName]]: "*default*",
>    [[ExportName]]: "default"}.
> 2. Return a new List containing entry.
> ```

Source:
http://www.ecma-international.org/ecma-262/6.0/#sec-exports-static-semantics-exportentries
