### PR TITLE
Fix #308: forbid 'yield' as an identifier in properties in generators

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1958,6 +1958,9 @@ export class GenericParser extends Tokenizer {
         return methodOrKey;
       case 'identifier':
         if (this.eat(TokenType.ASSIGN)) {
+          if (this.allowYieldExpression && token.value === 'yield') {
+            throw this.createError(ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+          }
           // CoverInitializedName
           let init = this.isolateCoverGrammar(this.parseAssignmentExpression);
           this.firstExprError = this.createErrorWithLocation(startLocation, ErrorMessages.ILLEGAL_PROPERTY);
@@ -1966,6 +1969,9 @@ export class GenericParser extends Tokenizer {
             init,
           }), startState);
         } else if (!this.match(TokenType.COLON)) {
+          if (this.allowYieldExpression && token.value === 'yield') {
+            throw this.createError(ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+          }
           if (token.type === TokenType.IDENTIFIER || token.value === 'let' || token.value === 'yield') {
             return this.finishNode(new AST.ShorthandProperty({ name: new AST.IdentifierExpression({ name: methodOrKey.value }) }), startState);
           }
@@ -2232,14 +2238,15 @@ export class GenericParser extends Tokenizer {
     let { name, binding } = this.parsePropertyName();
     if (isIdentifier && name.type === 'StaticPropertyName') {
       if (!this.match(TokenType.COLON)) {
+        if (this.allowYieldExpression && token.value === 'yield') {
+          throw this.createError(ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+        }
         let defaultValue = null;
         if (this.eat(TokenType.ASSIGN)) {
           let previousAllowYieldExpression = this.allowYieldExpression;
           let expr = this.parseAssignmentExpression();
           defaultValue = expr;
           this.allowYieldExpression = previousAllowYieldExpression;
-        } else if (token.value === 'yield' && this.allowYieldExpression) {
-          throw this.createError(ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
         }
         return this.finishNode(new AST.BindingPropertyIdentifier({
           binding,

--- a/test/declaration/generator-declaration.js
+++ b/test/declaration/generator-declaration.js
@@ -89,6 +89,22 @@ suite('Parser', function () {
         expression: { type: 'LiteralNumericExpression', value: 0 }
       });
 
+    testParse('function* a(){({yield:a}=0)}', function (p) {
+      return stmt(p).body.statements[0].expression;
+    },
+      {
+        type: 'AssignmentExpression',
+        binding: {
+          type: 'ObjectAssignmentTarget',
+          properties: [{
+            type: 'AssignmentTargetPropertyProperty',
+            name: { type: 'StaticPropertyName', value: 'yield' },
+            binding: { type: 'AssignmentTargetIdentifier', name: 'a' }
+          }]
+        },
+        expression: { type: 'LiteralNumericExpression', value: 0 }
+      });
+
     testParse('function* a() {} function a() {}', id,
       {
         type: 'Script',
@@ -147,6 +163,13 @@ suite('Parser', function () {
     testParseFailure('function*g() { var yield; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { let yield; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { try {} catch (yield) {} }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
-
+    testParseFailure('function*g() { ({yield}); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { ({yield} = 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { var {yield} = 0; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { for ({yield} in 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { ({yield = 0}); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { ({yield = 0} = 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { var {yield = 0} = 0; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { for ({yield = 0} in 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
   });
 });


### PR DESCRIPTION
This was a special case: `yield` was being parsed as a property name first, which avoided the usual logic preventing it from being used as an identifier.