### PR TITLE
Fix #325: assert location sanity in tests

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -103,5 +103,6 @@ export const ErrorMessages = {
   DUPLICATE_PROPTO_PROP: 'Duplicate __proto__ property in object literal not allowed',
   ILLEGAL_LABEL_FUNC_DECLARATION: 'Labeled FunctionDeclarations are disallowed in strict mode',
   ILLEGAL_FUNC_DECL_IF: 'FunctionDeclarations in IfStatements are disallowed in strict mode',
-  ILLEGAL_USE_STRICT: 'Functions with non-simple parameter lists may not contain a "use strict" directive'
+  ILLEGAL_USE_STRICT: 'Functions with non-simple parameter lists may not contain a "use strict" directive',
+  ILLEGAL_EXPORTED_NAME: 'Exported variables from the current module must be identifiers',
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -104,5 +104,5 @@ export const ErrorMessages = {
   ILLEGAL_LABEL_FUNC_DECLARATION: 'Labeled FunctionDeclarations are disallowed in strict mode',
   ILLEGAL_FUNC_DECL_IF: 'FunctionDeclarations in IfStatements are disallowed in strict mode',
   ILLEGAL_USE_STRICT: 'Functions with non-simple parameter lists may not contain a "use strict" directive',
-  ILLEGAL_EXPORTED_NAME: 'Exported variables from the current module must be identifiers',
+  ILLEGAL_EXPORTED_NAME: 'Names of variables used in an export specifier from the current module must be identifiers',
 };

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -1,7 +1,7 @@
 let expect = require('expect.js');
 let parse = require('../').parseScriptWithLocation;
 let parseModule = require('../').parseModuleWithLocation;
-// let locationSanityCheck = require('./helpers').locationSanityCheck;
+let locationSanityCheck = require('./helpers').locationSanityCheck;
 let schemaCheck = require('./helpers').schemaCheck;
 let SHIFT_SPEC = require('shift-spec').default;
 let Parser = require('../dist/parser').GenericParser;
@@ -11,9 +11,9 @@ exports.testParse = function testParse(program, accessor, expected) {
   let args = arguments.length;
   test(program, function () {
     expect(args).to.be(testParse.length);
-    let tree = parse(program).tree;
+    let {tree, locations} = parse(program)
     schemaCheck(tree, SHIFT_SPEC.Script);
-//    locationSanityCheck(tree);
+    locationSanityCheck(tree, locations);
     expect(accessor(parse(program, { earlyErrors: false }).tree)).to.eql(expected);
   });
 };
@@ -22,9 +22,9 @@ exports.testParseModule = function testParseModule(program, accessor, expected) 
   let args = arguments.length;
   test(program, function () {
     expect(args).to.be(testParseModule.length);
-    let tree = parseModule(program).tree;
+    let {tree, locations} = parseModule(program)
     schemaCheck(tree, SHIFT_SPEC.Module);
-//    locationSanityCheck(tree);
+    locationSanityCheck(tree, locations);
     expect(accessor(parseModule(program, { earlyErrors: false }).tree)).to.eql(expected);
   });
 };

--- a/test/expressions/class-expression.js
+++ b/test/expressions/class-expression.js
@@ -18,7 +18,6 @@ let testParse = require('../assertions').testParse;
 let testParseFailure = require('../assertions').testParseFailure;
 let expr = require('../helpers').expr;
 let stmt = require('../helpers').stmt;
-let testLocationSanity = require('../helpers').testLocationSanity;
 
 suite('Parser', function () {
   suite('class expression', function () {
@@ -322,18 +321,5 @@ suite('Parser', function () {
     testParseFailure('(class extends !a {})', 'Unexpected token "!"');
     testParseFailure('(class [a] {})', 'Unexpected token "["');
     testParseFailure('(class {[a,b](){}})', 'Unexpected token ","');
-
-    testLocationSanity('(class {})');
-    testLocationSanity('(class A {})');
-    testLocationSanity('(class A extends A{})');
-    testLocationSanity('(class extends A{})');
-    testLocationSanity('(class {a(){}})');
-    testLocationSanity('(class {[a](){}})');
-    testLocationSanity('(class {[a+b](){}})');
-    testLocationSanity('(class {get [a+b](){}})');
-    testLocationSanity('(class {set [a+b]([a]){}})');
-    testLocationSanity('(class {[a](){};})');
-    testLocationSanity('(class {[a](){};;})');
-    testLocationSanity('(class {static [a](){};;})');
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -159,8 +159,8 @@ function locationSanityCheck(tree, locations) {
         throw new Error('min >= max');
       }
       if (children) {
-        for (let child of Object.values(children)) {
-          checkSanity(ret, child);
+        for (let childName of Object.keys(children)) {
+          checkSanity(ret, children[childName]);
         }
       }
       return ret;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 /**
- * Copyright 2014 Shape Security, Inc.
+ * Copyright 2017 Shape Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 let expect = require('expect.js');
 let SHIFT_SPEC = require('shift-spec').default;
+let reduce = require('shift-reducer').default;
 
 function stmt(program) {
   return program.statements[0];
@@ -109,97 +110,69 @@ function schemaCheck(node, spec) {
   });
 }
 
-// let LT = -1, EQ = 0, GT = 1;
-
-// function sourceLocationCompare(loc1, loc2) {
-//   if (loc1.offset < loc2.offset) {
-//     if (loc1.line < loc2.line || loc1.line === loc2.line && loc1.column < loc2.column) {
-//       return LT;
-//     }
-//   } else if (loc1.offset === loc2.offset) {
-//     if (loc1.line === loc2.line && loc1.column === loc2.column) {
-//       return EQ;
-//     }
-//   } else if (loc1.line > loc2.line || loc1.line === loc2.line && loc1.column > loc2.column) {
-//     return GT;
-//   }
-//   expect().fail('inconsistent location information.');
-// }
-
-// function expectSourceSpanContains(parent, loc) {
-//   if (sourceLocationCompare(parent.start, loc.start) > EQ || sourceLocationCompare(parent.end, loc.end) < EQ) {
-//     expect().fail('Parent does not include child');
-//   }
-// }
-
 function moduleItem(mod) {
   return mod.items[0];
 }
 
-// function checkLocation(loc) {
-//   if (!loc) {
-//     expect().fail('Node has no location');
-//   }
-//   if (loc.start.column < 0 ||
-//     loc.start.line < 0 ||
-//     loc.start.offset < 0 ||
-//     loc.end.column < 0 ||
-//     loc.end.line < 0 ||
-//     loc.end.offset < 0) {
-//     expect().fail('Illegal location information');
-//   }
-// }
-
-function testLocationSanity() {
-  return;
+function checkSanity(range, child) {
+  if (Array.isArray(child)) {
+    let lower = range.min;
+    for (let item of child) {
+      if (child.min < lower) {
+        throw new Error('list-lower out of order');
+      }
+      lower = child.max;
+    }
+    if (lower > range.max) {
+      throw new Error('list-upper out of order');
+    }
+  } else if (child !== null) {
+    if (child.min < range.min || child.max > range.max) {
+      throw new Error('child exceeds parent');
+    }
+  }
 }
 
-// function locationSanityCheck(node, parentSpan, prevLocation) {
-//   return; // todo move to side-table style location and check this in testParse etc
-  // let loc = node.loc;
+function locationSanityCheck(tree, locations) {
+  let rangeChecker = {};
 
-  // checkLocation(node.loc);
+  for (let typeName of Object.keys(SHIFT_SPEC)) {
+    rangeChecker[`reduce${typeName}`] = function(node, children) {
+      if (!locations.has(node)) {
+        if (node.type === 'BindingIdentifier' && node.name === '*default*') {
+          // the artificial BindingIdentifier for export default unnamed function/class has no location information.
+          return null;
+        }
+        throw new Error(`${node.type} missing location information`);
+      }
+      let loc = locations.get(node);
 
-  // let compareEnds = sourceLocationCompare(node.loc.start, node.loc.end);
-  // if (compareEnds === GT) {
-  //   expect().fail('Location information indicates that the node has negative length');
-  // }
+      let ret = { min: loc.start.offset, max: loc.end.offset };
+      if (ret.min >= ret.max) {
+        // The only legitimately empty nodes are empty scripts/modules.
+        if (node.type === 'Script' && node.directives.length === 0 && node.statements.length === 0) {
+          return null;
+        }
+        if (node.type === 'Module' && node.items.length === 0) {
+          return null;
+        }
+        throw new Error('min >= max');
+      }
+      if (children) {
+        for (let child of Object.values(children)) {
+          checkSanity(ret, child);
+        }
+      }
+      return ret;
+    }
+  }
 
-  // if (prevLocation) {
-  //   if (sourceLocationCompare(prevLocation, loc.start) > EQ) {
-  //     expect().fail('Nodes overlap');
-  //   }
-  // }
-  // if (parentSpan) {
-  //   expectSourceSpanContains(parentSpan, loc);
-  // }
-  // let last = null;
-  // let spec = SHIFT_SPEC[node.type].fields;
-  // for (let i = 0; i < spec.length; i++) {
-  //   let field = spec[i];
-  //   if (node[field.name] === null) return;
-  //   // *default* BindingIdentifier nodes don't have a representation in the program text
-  //   if (node[field.name].type === 'BindingIdentifier' && node[field.name].name === '*default*') {
-  //     return;
-  //   }
-  //   if (typeof node[field.name].type === 'string') {  // subnode
-  //     locationSanityCheck(node[field.name], loc, last);
-  //     last = node[field.name].loc.end;
-  //   } else if (Array.isArray(node[field.name])) {
-  //     let childList = node[field.name];
-  //     for (let j = 0; j < childList.length; j++) {
-  //       let child = childList[j];
-  //       if (!child) return;
-  //       locationSanityCheck(child, loc, last);
-  //       last = child.loc.end;
-  //     }
-  //   }
-  // }
-// }
+  reduce(rangeChecker, tree);
+}
+
 
 exports.moduleItem = moduleItem;
 exports.expr = expr;
 exports.stmt = stmt;
-// exports.locationSanityCheck = locationSanityCheck;
-exports.testLocationSanity = testLocationSanity;
+exports.locationSanityCheck = locationSanityCheck;
 exports.schemaCheck = schemaCheck;

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -149,12 +149,14 @@ function locationSanityCheck(tree, locations) {
 
       let ret = { min: loc.start.offset, max: loc.end.offset };
       if (ret.min >= ret.max) {
-        // The only legitimately empty nodes are empty scripts/modules.
-        if (node.type === 'Script' && node.directives.length === 0 && node.statements.length === 0) {
-          return null;
-        }
-        if (node.type === 'Module' && node.items.length === 0) {
-          return null;
+        if (ret.min === ret.max) {
+          // The only legitimately empty nodes are empty scripts/modules.
+          if (node.type === 'Script' && node.directives.length === 0 && node.statements.length === 0) {
+            return null;
+          }
+          if (node.type === 'Module' && node.items.length === 0 && ret.min === 0 && ret.max === 0) {
+            return null;
+          }
         }
         throw new Error('min >= max');
       }

--- a/test/modules/export.js
+++ b/test/modules/export.js
@@ -370,6 +370,6 @@ suite('Parser', function () {
     testParseModuleFailure('export function () {}', 'Unexpected token "("');
     testParseModuleFailure('export default default', 'Unexpected token "default"');
     testParseModuleFailure('export default function', 'Unexpected end of input');
-    testParseModuleFailure('export {with as a}', 'Exported variables from the current module must be identifiers');
+    testParseModuleFailure('export {with as a}', 'Names of variables used in an export specifier from the current module must be identifiers');
   });
 });

--- a/test/modules/export.js
+++ b/test/modules/export.js
@@ -41,6 +41,12 @@ suite('Parser', function () {
       moduleSpecifier: 'a'
     });
 
+    testExportDecl('export {with} from "a"', {
+      type: 'ExportFrom',
+      namedExports: [{ type: 'ExportFromSpecifier', name: 'with', exportedName: null }],
+      moduleSpecifier: 'a'
+    });
+
     testExportDecl('export {a,} from "a"', {
       type: 'ExportFrom',
       namedExports: [{ type: 'ExportFromSpecifier', name: 'a', exportedName: null }],
@@ -60,6 +66,12 @@ suite('Parser', function () {
     testExportDecl('export {a as b} from "a"', {
       type: 'ExportFrom',
       namedExports: [{ type: 'ExportFromSpecifier', name: 'a', exportedName: 'b' }],
+      moduleSpecifier: 'a'
+    });
+
+    testExportDecl('export {with as a} from "a"', {
+      type: 'ExportFrom',
+      namedExports: [{ type: 'ExportFromSpecifier', name: 'with', exportedName: 'a' }],
       moduleSpecifier: 'a'
     });
 

--- a/test/modules/export.js
+++ b/test/modules/export.js
@@ -358,5 +358,6 @@ suite('Parser', function () {
     testParseModuleFailure('export function () {}', 'Unexpected token "("');
     testParseModuleFailure('export default default', 'Unexpected token "default"');
     testParseModuleFailure('export default function', 'Unexpected end of input');
+    testParseModuleFailure('export {with as a}', 'Exported variables from the current module must be identifiers');
   });
 });


### PR DESCRIPTION
This does not currently run for test262-parser-tests. Perhaps it should?