### PR TITLE
Fix #347: allow , in RHS of for-in

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -663,7 +663,7 @@ export class GenericParser extends Tokenizer {
             }
             ctor = AST.ForInStatement;
             this.lex();
-            right = this.parseAssignmentExpression();
+            right = this.parseExpression();
           } else {
             if (init.declarators[0].init != null) {
               throw this.createError(ErrorMessages.INVALID_VAR_INIT_FOR_OF);
@@ -703,10 +703,16 @@ export class GenericParser extends Tokenizer {
           if (startsWithLet && this.matchContextualKeyword('of')) {
             throw this.createError(ErrorMessages.INVALID_LHS_IN_FOR_OF);
           }
-          let ctor = this.match(TokenType.IN) ? AST.ForInStatement : AST.ForOfStatement;
-
-          this.lex();
-          right = this.parseAssignmentExpression();
+          let ctor;
+          if (this.match(TokenType.IN)) {
+            ctor = AST.ForInStatement;
+            this.lex();
+            right = this.parseExpression();
+          } else {
+            ctor = AST.ForOfStatement;
+            this.lex();
+            right = this.parseAssignmentExpression();
+          }
 
           return new ctor({ left: this.transformDestructuring(expr), right, body: this.getIteratorStatementEpilogue() });
         } else {

--- a/test/statements/for-in-statement.js
+++ b/test/statements/for-in-statement.js
@@ -188,14 +188,38 @@ suite('Parser', function () {
       body: { type: 'EmptyStatement' }
     });
 
+    testParse('for(var a in b, c);', stmt, {
+      type: 'ForInStatement',
+      left: {
+        type: 'VariableDeclaration',
+        kind: 'var',
+        declarators: [{ type: 'VariableDeclarator', binding: { type: 'BindingIdentifier', name: 'a' }, init: null }]
+      },
+      right: {
+        type: 'BinaryExpression',
+        operator: ',',
+        left: { type: 'IdentifierExpression', name: 'b' },
+        right: { type: 'IdentifierExpression', name: 'c' },
+      },
+      body: { type: 'EmptyStatement' }
+    });
+    testParse('for(a in b, c);', stmt, {
+      type: 'ForInStatement',
+      left: { type: 'AssignmentTargetIdentifier', name: 'a' },
+      right: {
+        type: 'BinaryExpression',
+        operator: ',',
+        left: { type: 'IdentifierExpression', name: 'b' },
+        right: { type: 'IdentifierExpression', name: 'c' },
+      },
+      body: { type: 'EmptyStatement' }
+    });
+
     testParseFailure('for(let a = 0 in b);', 'Invalid variable declaration in for-in statement');
     testParseFailure('for(const a = 0 in b);', 'Invalid variable declaration in for-in statement');
     testParseFailure('for(let ? b : c in 0);', 'Invalid left-hand side in for-in');
 
     testParseFailure('for(({a}) in 0);', 'Invalid left-hand side in for-in');
     testParseFailure('for(([a]) in 0);', 'Invalid left-hand side in for-in');
-
-    testParseFailure('for(var a in b, c);', 'Unexpected token ","');
-    testParseFailure('for(a in b, c);', 'Unexpected token ","');
   });
 });


### PR DESCRIPTION
We're [already testing](https://github.com/shapesecurity/shift-parser-js/blob/4c14c202d64d0ad75157d959fe2d64978722831d/test/statements/for-of-statement.js#L159-L160) that it's disallowed in for-of, as it should be.