### PR TITLE
Allow super in computed method names as appropriate

### DIFF
--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -182,8 +182,6 @@ export class EarlyErrorChecker extends MonoidalReducer {
       s = this.append(s, _super);
       sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
     }
-    sElements = sElements.enforceSuperCallExpressions(SUPERCALL_ERROR);
-    sElements = sElements.enforceSuperPropertyExpressions(SUPERPROPERTY_ERROR);
     s = this.append(s, sElements);
     s = enforceDuplicateConstructorMethods(node, s);
     s = s.observeLexicalDeclaration();
@@ -210,8 +208,6 @@ export class EarlyErrorChecker extends MonoidalReducer {
       s = this.append(s, _super);
       sElements = sElements.clearSuperCallExpressionsInConstructorMethod();
     }
-    sElements = sElements.enforceSuperCallExpressions(SUPERCALL_ERROR);
-    sElements = sElements.enforceSuperPropertyExpressions(SUPERPROPERTY_ERROR);
     s = this.append(s, sElements);
     s = enforceDuplicateConstructorMethods(node, s);
     s = s.clearBoundNames();

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -29,6 +29,16 @@ exports.testParseModule = function testParseModule(program, accessor, expected) 
   });
 };
 
+exports.testParseSuccess = function testParseSuccess(program) {
+  let args = arguments.length;
+  test(program, function () {
+    expect(args).to.be(testParseSuccess.length);
+    let {tree, locations} = parse(program)
+    schemaCheck(tree, SHIFT_SPEC.Script);
+    locationSanityCheck(tree, locations);
+  });
+};
+
 exports.testParseFailure = function testParseFailure(source, message) {
   let args = arguments.length;
   test('Expect failure in Script: ' + source, function () {

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -767,6 +767,7 @@ suite('Parser', function () {
     testEarlyError('super.a', ErrorMessages.ILLEGAL_ACCESS_SUPER_MEMBER);
     testEarlyError('(class {[super()](){}});', ErrorMessages.INVALID_CALL_TO_SUPER);
     testEarlyError('(class {[super.a](){}});', ErrorMessages.ILLEGAL_ACCESS_SUPER_MEMBER);
+    testEarlyError('(class {a(b = super()){}});', ErrorMessages.INVALID_CALL_TO_SUPER);
     // It is a Syntax Error if StatementList Contains NewTarget unless the source code containing
     // NewTarget is eval code that is being processed by a direct eval that is contained in function code.
     // However, such function code does not include ArrowFunction function code.

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -725,6 +725,7 @@ suite('Parser', function () {
     //   3. Return HasDirectSuper of constructor.
     testEarlyError('class A { constructor() { super(); } }', ErrorMessages.INVALID_CALL_TO_SUPER);
     testEarlyError('class A { constructor() { {{ (( super() )); }} } }', ErrorMessages.INVALID_CALL_TO_SUPER);
+    testEarlyError('class A { constructor() { (class {[super()](){}}); } }', ErrorMessages.INVALID_CALL_TO_SUPER);
     // It is a Syntax Error if PrototypePropertyNameList of ClassElementList contains more than
     // one occurrence of "constructor".
     testEarlyError('class A { constructor(){} constructor(){} }', ErrorMessages.DUPLICATE_CONSTRUCTOR);
@@ -764,6 +765,8 @@ suite('Parser', function () {
     // However, such function code does not include ArrowFunction function code.
     testEarlyError('super()', ErrorMessages.INVALID_CALL_TO_SUPER);
     testEarlyError('super.a', ErrorMessages.ILLEGAL_ACCESS_SUPER_MEMBER);
+    testEarlyError('(class {[super()](){}});', ErrorMessages.INVALID_CALL_TO_SUPER);
+    testEarlyError('(class {[super.a](){}});', ErrorMessages.ILLEGAL_ACCESS_SUPER_MEMBER);
     // It is a Syntax Error if StatementList Contains NewTarget unless the source code containing
     // NewTarget is eval code that is being processed by a direct eval that is contained in function code.
     // However, such function code does not include ArrowFunction function code.

--- a/test/expressions/class-expression.js
+++ b/test/expressions/class-expression.js
@@ -314,6 +314,8 @@ suite('Parser', function () {
 
     testParseSuccess('({ a(){ (class {[super.a](){}}); } })');
     testParseSuccess('class A extends Object { constructor(){ (class {[super()](){}}); } }');
+    testParseSuccess('class A extends Object { constructor(a = super()){} }');
+    testParseSuccess('class A { b(c = super.d){} }');
 
     testParseFailure('(class {a:0})', 'Only methods are allowed in classes');
     testParseFailure('(class {a=0})', 'Only methods are allowed in classes');

--- a/test/expressions/class-expression.js
+++ b/test/expressions/class-expression.js
@@ -16,6 +16,7 @@
 
 let testParse = require('../assertions').testParse;
 let testParseFailure = require('../assertions').testParseFailure;
+let testParseSuccess = require('../assertions').testParseSuccess;
 let expr = require('../helpers').expr;
 let stmt = require('../helpers').stmt;
 
@@ -310,6 +311,9 @@ suite('Parser', function () {
         }
       }]
     });
+
+    testParseSuccess('({ a(){ (class {[super.a](){}}); } })');
+    testParseSuccess('class A extends Object { constructor(){ (class {[super()](){}}); } }');
 
     testParseFailure('(class {a:0})', 'Only methods are allowed in classes');
     testParseFailure('(class {a=0})', 'Only methods are allowed in classes');


### PR DESCRIPTION
Fixes #358.

I introduced a `testParseSuccess` which allows asserting a parse succeeds without writing out the whole tree for it, because sometimes you don't actually care to assert that something is parsed to a particular AST.