### PR TITLE
ParserWithLocation now also reports locations of comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Location information is available in environments which support `WeakMap` via an
 
 ```js
 let {parseScriptWithLocation, parseModuleWithLocation} = require("shift-parser");
-let {tree, locations} = parseScriptWithLocation("2 + 3");
+let {tree, locations, commentSpans} = parseScriptWithLocation("2 + 3 /* = 5 */");
 let threeNode = tree.statements[0].expression.right;
 locations.get(threeNode); // { start: { line: 1, column: 4, offset: 4 }, end: { line: 1, column: 5, offset: 5 } }
+commentSpans; // [ [ { line: 1, column: 6, offset: 6 }, { line: 1, column: 15, offset: 15 } ] ]
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser",
-  "version": "5.0.7",
+  "version": "5.1.0",
   "description": "ECMAScript parser that produces a Shift format AST",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-parser-js",


### PR DESCRIPTION
As an array of `[ start, end ]` pairs; see readme.

Includes a version bump commit, so please **rebase**, not squash.

This change turned out to be a lot easier than I was expecting.

Edit to add: fixes #352 (at least, to the extent I expect it ever to be fixed).