### PR TITLE
Forbid \08 in strict strings

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -105,4 +105,5 @@ export const ErrorMessages = {
   ILLEGAL_FUNC_DECL_IF: 'FunctionDeclarations in IfStatements are disallowed in strict mode',
   ILLEGAL_USE_STRICT: 'Functions with non-simple parameter lists may not contain a "use strict" directive',
   ILLEGAL_EXPORTED_NAME: 'Names of variables used in an export specifier from the current module must be identifiers',
+  NO_OCTALS_IN_TEMPLATES: 'Template literals may not contain octal escape sequences',
 };

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -1268,6 +1268,9 @@ export default class Tokenizer {
               }
               ch = this.source.charAt(this.index);
             }
+            if (code === 0 && octLen === 1 && (ch === '8' || ch === '9')) {
+              octal = this.source.slice(octalStart, this.index + 1);
+            }
             str += String.fromCharCode(code);
           } else if (ch === '8' || ch === '9') {
             throw this.createILLEGAL();
@@ -1331,7 +1334,7 @@ export default class Tokenizer {
         case 0x5C: { // \\
           let octal = this.scanStringEscape('', null)[1];
           if (octal != null) {
-            throw this.createILLEGAL();
+            throw this.createError(ErrorMessages.NO_OCTALS_IN_TEMPLATES);
           }
           break;
         }

--- a/test/expressions/literals/literal-string-expression.js
+++ b/test/expressions/literals/literal-string-expression.js
@@ -44,6 +44,8 @@ suite('Parser', () => {
     testParseFailure('\'use strict\'; (\'\\001\')', 'Unexpected legacy octal escape sequence: \\001');
     testParseFailure('\'use strict\'; (\'\\000\')', 'Unexpected legacy octal escape sequence: \\000');
     testParseFailure('\'use strict\'; (\'\\123\')', 'Unexpected legacy octal escape sequence: \\123');
+    testParseFailure('\'use strict\'; (\'\\08\')', 'Unexpected legacy octal escape sequence: \\08');
+    testParseFailure('\'use strict\'; (\'\\09\')', 'Unexpected legacy octal escape sequence: \\09');
     testParseModuleFailure('(\'\\1\')', 'Unexpected legacy octal escape sequence: \\1');
 
     // early grammar error: 11.8.4.1

--- a/test/expressions/template-expression.js
+++ b/test/expressions/template-expression.js
@@ -18,6 +18,7 @@
 let testParse = require('../assertions').testParse;
 let testParseFailure = require('../assertions').testParseFailure;
 let expr = require('../helpers').expr;
+let errorMessages = require('../../dist/errors').ErrorMessages;
 
 suite('Parser', () => {
   suite('untagged template expressions', () => {
@@ -27,7 +28,18 @@ suite('Parser', () => {
     testParseFailure('a++``', 'Unexpected template');
     testParseFailure('`${a', 'Unexpected end of input');
     testParseFailure('`${a}a${b}', 'Unexpected end of input');
-    testParseFailure('`\\37`', 'Unexpected "`"');
+
+    testParseFailure('`\\1`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\4`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\11`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\41`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\01`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\00`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\001`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\000`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\123`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\08`', errorMessages.NO_OCTALS_IN_TEMPLATES);
+    testParseFailure('`\\09`', errorMessages.NO_OCTALS_IN_TEMPLATES);
   });
 
   suite('tagged template expressions', () => {


### PR DESCRIPTION
Fixes #360.

Pretty much the same patch as I made to [v8](https://codereview.chromium.org/2948903002/patch/1/10001).

Also improves the error message for octals in templataes.