### PR TITLE
Validate fn "name" when enforcing strict mode

### DIFF
--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -174,7 +174,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
   }
 
   reduceClassDeclaration(node, { name, super: _super, elements }) {
-    let s = name;
+    let s = name.enforceStrictErrors();
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {
@@ -200,7 +200,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
   }
 
   reduceClassExpression(node, { name, super: _super, elements }) {
-    let s = node.name == null ? this.identity : name;
+    let s = node.name == null ? this.identity : name.enforceStrictErrors();
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {
@@ -372,6 +372,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
     params = params.clearNewTargetExpressions();
     body = body.clearNewTargetExpressions();
     if (isStrictFunctionBody(node.body)) {
+      name = name.enforceStrictErrors();
       params = params.enforceStrictErrors();
       body = body.enforceStrictErrors();
     }
@@ -407,6 +408,9 @@ export class EarlyErrorChecker extends MonoidalReducer {
     params = params.clearNewTargetExpressions();
     body = body.clearNewTargetExpressions();
     if (isStrictFunctionBody(node.body)) {
+      if (name) {
+        name = name.enforceStrictErrors();
+      }
       params = params.enforceStrictErrors();
       body = body.enforceStrictErrors();
     }


### PR DESCRIPTION
Commit message:

> TC39 reached consensus in March 2018 to extend the definition of the
> term "function code" to include the BindingIdentifier informally
> referred to as the function's "name" in those productions which include
> it [1]. This has the effect of restricting the set of valid identifiers
> for functions whose bodies include a "use strict" directive.
>
> Because the project's test suite does not include tests for this case,
> no change to existing test material is necessary. However, the
> `test262-parser-tests` project *does* require modification, so this
> patch should not be applied until that project has been updated
> accordingly [2].
>
> [1] https://github.com/tc39/ecma262/pull/1158
> [2] https://github.com/tc39/test262-parser-tests/pull/17

Would you folks like me to also add tests directly into this project?