### PR TITLE
Add more tests for `yield` as LHS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "es6-map": "^0.1.1",
     "multimap": "^0.1.1",
     "shift-ast": "^4.0.0",
-    "shift-reducer": "^4.0.0"
+    "shift-reducer": "^4.4.0"
   },
   "devDependencies": {
     "acorn": "2.1.0",
@@ -42,18 +42,18 @@
     "esprima": "2.5.0",
     "everything.js": "1.0.3",
     "expect.js": "0.3.1",
-    "microtime": "^2.0.0",
+    "microtime": "^2.1.8",
     "mocha": "2.3.4",
     "normalize-parser-test": "1.0.3",
     "nyc": "10.1.2",
-    "regenerate": "^1.3.2",
+    "regenerate": "^1.4.0",
     "shift-parser-expectations": "2016.0.1",
     "shift-spec": "^2016.0.0",
     "test262-parser-tests": "0.0.3",
     "tick": "0.1.1",
     "traceur": "0.0.91",
     "uglifyjs": "2.4.10",
-    "unicode-8.0.0": "^0.7.0"
+    "unicode-8.0.0": "^0.7.5"
   },
   "keywords": [
     "Shift",

--- a/test/declaration/generator-declaration.js
+++ b/test/declaration/generator-declaration.js
@@ -61,7 +61,10 @@ suite('Parser', () => {
     testParseFailure('function*g() { ({yield} = 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { var {yield} = 0; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { for ({yield} in 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { for ({yield} in [{}]); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { for ({yield} of [{}]); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { ({yield = 0}); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
+    testParseFailure('function*g() { 0, {yield} = {}; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { ({yield = 0} = 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { var {yield = 0} = 0; }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);
     testParseFailure('function*g() { for ({yield = 0} in 0); }', ErrorMessages.ILLEGAL_YIELD_IDENTIFIER);


### PR DESCRIPTION
These assert that the cases in https://github.com/shapesecurity/shift-parser-js/issues/308#issuecomment-390309859 are addressed.