### PR TITLE
add tests for await as identifier in scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "expect.js": "0.3.1",
     "microtime": "^2.1.8",
     "mocha": "2.3.4",
-    "normalize-parser-test": "1.0.3",
+    "normalize-parser-test": "1.0.4",
     "nyc": "10.1.2",
     "regenerate": "^1.4.0",
     "shift-parser-expectations": "2016.0.1",

--- a/test/expressions/assignment-expression.js
+++ b/test/expressions/assignment-expression.js
@@ -16,11 +16,25 @@
 
 let testParse = require('../assertions').testParse;
 let testParseFailure = require('../assertions').testParseFailure;
+let testParseModuleFailure = require('../assertions').testParseModuleFailure;
 let expr = require('../helpers').expr;
 
 suite('Parser', () => {
   suite('assignment expression', () => {
 
+    testParse('await = 0', expr,
+      {
+        type: 'AssignmentExpression',
+        binding: {
+          type: 'AssignmentTargetIdentifier',
+          name: 'await',
+        },
+        expression: {
+          type: 'LiteralNumericExpression',
+          value: 0,
+        },
+      }
+    );
 
     testParse('x **= 0', expr,
       {
@@ -47,6 +61,8 @@ suite('Parser', () => {
         },
         expression: { type: 'LiteralNumericExpression', value: 0 },
       });
+
+    testParseModuleFailure('await = 0', 'Unexpected token "await"');
 
     testParseFailure('(({a})=0);', 'Invalid left-hand side in assignment');
     testParseFailure('(([a])=0);', 'Invalid left-hand side in assignment');

--- a/test/expressions/identifier-expression.js
+++ b/test/expressions/identifier-expression.js
@@ -22,6 +22,7 @@ let stmt = require('../helpers').stmt;
 
 suite('Parser', () => {
   suite('identifier expression', () => {
+    testParse('await', expr, { type: 'IdentifierExpression', name: 'await' });
     testParseModuleFailure('await', 'Unexpected token "await"');
     testParseModuleFailure('function f() { var await }', 'Unexpected token "await"');
 

--- a/test/statements/variable-declaration-statement.js
+++ b/test/statements/variable-declaration-statement.js
@@ -18,10 +18,29 @@ let stmt = require('../helpers').stmt;
 let expr = require('../helpers').expr;
 let testParse = require('../assertions').testParse;
 let testParseFailure = require('../assertions').testParseFailure;
+let testParseModuleFailure = require('../assertions').testParseModuleFailure;
 
 suite('Parser', () => {
   suite('variable declaration statement', () => {
     // Variable Statement
+
+    testParse('var await;', stmt,
+      {
+        type: 'VariableDeclarationStatement',
+        declaration: {
+          type: 'VariableDeclaration',
+          kind: 'var',
+          declarators: [{
+            type: 'VariableDeclarator',
+            binding: {
+              type: 'BindingIdentifier',
+              name: 'await',
+            },
+            init: null,
+          }],
+        },
+      }
+    );
 
 
     // Let Statement
@@ -33,6 +52,7 @@ suite('Parser', () => {
     // Const Statement
 
 
+    testParseModuleFailure('var await', 'Unexpected token "await"');
     testParseFailure('var const', 'Unexpected token "const"');
     testParseFailure('var a[0]=0;', 'Unexpected token "["');
     testParseFailure('var (a)=0;', 'Unexpected token "("');


### PR DESCRIPTION
Depends on https://github.com/bakkot/normalize-parser-test/pull/2 (otherwise `var await;` is considered to be the same test as `var a;`, which already exists in test262-parser-tests; the test runner enforces no duplicates with that suite, so this fails).