### PR TITLE
Some semantics-preserving changes

### DIFF
--- a/src/early-errors.js
+++ b/src/early-errors.js
@@ -174,7 +174,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
   }
 
   reduceClassDeclaration(node, { name, super: _super, elements }) {
-    let s = name;
+    let s = name.enforceStrictErrors();
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {
@@ -200,7 +200,7 @@ export class EarlyErrorChecker extends MonoidalReducer {
   }
 
   reduceClassExpression(node, { name, super: _super, elements }) {
-    let s = node.name == null ? this.identity : name;
+    let s = node.name == null ? this.identity : name.enforceStrictErrors();
     let sElements = this.fold(elements);
     sElements = sElements.enforceStrictErrors();
     if (node.super != null) {

--- a/src/tokenizer.js
+++ b/src/tokenizer.js
@@ -86,6 +86,7 @@ export const TokenType = {
   IN: { klass: TokenClass.Keyword, name: 'in' },
   NOT: { klass: TokenClass.Punctuator, name: '!' },
   BIT_NOT: { klass: TokenClass.Punctuator, name: '~' },
+  ASYNC: { klass: TokenClass.Keyword, name: 'async' },
   AWAIT: { klass: TokenClass.Keyword, name: 'await' },
   ENUM: { klass: TokenClass.Keyword, name: 'enum' },
   DELETE: { klass: TokenClass.Keyword, name: 'delete' },
@@ -403,7 +404,10 @@ export default class Tokenizer {
       case 5:
         switch (id.charAt(0)) {
           case 'a':
-            if (this.moduleIsTheGoalSymbol && Tokenizer.cse4(id, 'w', 'a', 'i', 't')) {
+            if (Tokenizer.cse4(id, 's', 'y', 'n', 'c')) {
+              return TokenType.ASYNC;
+            }
+            if (Tokenizer.cse4(id, 'w', 'a', 'i', 't')) {
               return TokenType.AWAIT;
             }
             break;

--- a/test/declaration/class-declaration.js
+++ b/test/declaration/class-declaration.js
@@ -21,6 +21,34 @@ let stmt = require('../helpers').stmt;
 suite('Parser', () => {
   suite('class declaration', () => {
 
+    testParse('class await {}', stmt, {
+      type: 'ClassDeclaration',
+      name: { type: 'BindingIdentifier', name: 'await' },
+      super: null,
+      elements: [],
+    });
+
+    testParse('class a\\u{77}ait {}', stmt, {
+      type: 'ClassDeclaration',
+      name: { type: 'BindingIdentifier', name: 'await' },
+      super: null,
+      elements: [],
+    });
+
+    testParse('class async {}', stmt, {
+      type: 'ClassDeclaration',
+      name: { type: 'BindingIdentifier', name: 'async' },
+      super: null,
+      elements: [],
+    });
+
+    testParse('class a\\u{73}ync {}', stmt, {
+      type: 'ClassDeclaration',
+      name: { type: 'BindingIdentifier', name: 'async' },
+      super: null,
+      elements: [],
+    });
+
     testParseFailure('class {}', 'Unexpected token "{"');
     testParseFailure('class extends A{}', 'Unexpected token "extends"');
   });

--- a/test/early-errors.js
+++ b/test/early-errors.js
@@ -219,6 +219,15 @@ suite('Parser', () => {
     testEarlyError('!{ set a(let) { \'use strict\'; } }', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
     testEarlyError('!{ a(let) { \'use strict\'; } }', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
     testEarlyError('!{ a(let) { \'use strict\'; } }', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
+
+    testEarlyError('class let {}', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
+    testEarlyError('class l\\u{65}t {}', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
+    testEarlyError('class yield {}', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('yield'));
+    testEarlyError('class yi\\u{65}ld {}', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('yield'));
+    testEarlyError('(class let {})', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
+    testEarlyError('(class l\\u{65}t {})', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('let'));
+    testEarlyError('(class yield {})', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('yield'));
+    testEarlyError('(class yi\\u{65}ld {})', ErrorMessages.INVALID_ID_BINDING_STRICT_MODE('yield'));
     // It is a Syntax Error if StringValue of IdentifierName is the same string value as the StringValue of any
     // ReservedWord except for yield.
     // TODO: these should fail but will not

--- a/test/expressions/object-expression.js
+++ b/test/expressions/object-expression.js
@@ -32,6 +32,46 @@ suite('Parser', () => {
       }
     );
 
+    testParse('({ let })', expr,
+      {
+        type: 'ObjectExpression',
+        properties: [{
+          type: 'ShorthandProperty',
+          name: { type: 'IdentifierExpression', name: 'let' },
+        }],
+      }
+    );
+
+    testParse('({ yield })', expr,
+      {
+        type: 'ObjectExpression',
+        properties: [{
+          type: 'ShorthandProperty',
+          name: { type: 'IdentifierExpression', name: 'yield' },
+        }],
+      }
+    );
+
+    testParse('({ async })', expr,
+      {
+        type: 'ObjectExpression',
+        properties: [{
+          type: 'ShorthandProperty',
+          name: { type: 'IdentifierExpression', name: 'async' },
+        }],
+      }
+    );
+
+    testParse('({ await })', expr,
+      {
+        type: 'ObjectExpression',
+        properties: [{
+          type: 'ShorthandProperty',
+          name: { type: 'IdentifierExpression', name: 'await' },
+        }],
+      }
+    );
+
 
     testParse('({a, b: 0, c})', expr,
       {


### PR DESCRIPTION
Split this out from the async-await work, since it makes sense in an ES2016 context as well.

One of these changes is actually a bugfix: currently `class let {}` is rejected by the _parser_, rather than the early error checker, which means that if you manually construct the following well-typed AST:

```js
{
  type: 'Script',
  directives: [],
  statements: [
    {
      type: 'ClassDeclaration',
      name: { type: 'BindingIdentifier', name: 'let' },
      super: null,
      elements: []
    }
  ]
}
```

this will pass both the validator and the early error checker, which violates their collective contract.

(ditto for other strict-mode reserved words).

The change to `parseArguments` is unrelated, but necessary for other work (specifically async arrows), so I'd like it to at least run through CI. It shouldn't change anything.