### PR TITLE
Remove dead state tracking

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -2038,11 +2038,9 @@ export class GenericParser extends Tokenizer {
         };
       }
       case TokenType.LBRACK: {
-        let previousYield = this.allowYieldExpression;
         this.lex();
         let expr = this.parseAssignmentExpression();
         this.expect(TokenType.RBRACK);
-        this.allowYieldExpression = previousYield;
         return { name: this.finishNode(new AST.ComputedPropertyName({ expression: expr }), startState), binding: null };
       }
     }
@@ -2268,10 +2266,7 @@ export class GenericParser extends Tokenizer {
         }
         let defaultValue = null;
         if (this.eat(TokenType.ASSIGN)) {
-          let previousAllowYieldExpression = this.allowYieldExpression;
-          let expr = this.parseAssignmentExpression();
-          defaultValue = expr;
-          this.allowYieldExpression = previousAllowYieldExpression;
+          defaultValue = this.parseAssignmentExpression();
         }
         return this.finishNode(new AST.BindingPropertyIdentifier({
           binding,
@@ -2320,10 +2315,8 @@ export class GenericParser extends Tokenizer {
     let binding = this.parseBindingTarget();
 
     if (this.eat(TokenType.ASSIGN)) {
-      let previousYieldExpression = this.allowYieldExpression;
       let init = this.parseAssignmentExpression();
       binding = this.finishNode(new AST.BindingWithDefault({ binding, init }), startState);
-      this.allowYieldExpression = previousYieldExpression;
     }
     return binding;
   }


### PR DESCRIPTION
Every function which modifies `allowYieldExpression` restores its original state before returning, so these did precisely nothing.

I imagine there used to be (incorrect) `this.allowYieldExpression = false` statements following the initial `previousYield = this.allowYieldExpression` which were removed without removing the attendant code.