### PR TITLE
Prevent await expression from being treated as an assignment target

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -1450,6 +1450,7 @@ export class GenericParser extends Tokenizer {
 
     let startState = this.startNode();
     if (this.allowAwaitExpression && this.eat(TokenType.AWAIT)) {
+      this.isBindingElement = this.isAssignmentTarget = false;
       let expression = this.isolateCoverGrammar(this.parseUnaryExpression);
       return this.finishNode(new AST.AwaitExpression({ expression }), startState);
     }

--- a/test/miscellaneous/async-await.js
+++ b/test/miscellaneous/async-await.js
@@ -670,6 +670,35 @@ suite('async', () => {
     );
   });
 
+  testParse('(async function() { (await y); })', expr,
+    {
+      type: 'FunctionExpression',
+      name: null,
+      isAsync: true,
+      isGenerator: false,
+      params: {
+        type: 'FormalParameters',
+        rest: null,
+        items: [],
+      },
+      body: {
+        type: 'FunctionBody',
+        directives: [],
+        statements: [
+          {
+            type: 'ExpressionStatement',
+            expression: {
+              type: 'AwaitExpression',
+              expression: {
+                type: 'IdentifierExpression',
+                name: 'y',
+              },
+            },
+          },
+        ],
+      },
+    });
+
   suite('failures', () => {
     testParseFailure('async (a, ...b, ...c) => {}', 'Unexpected token ","');
     testParseFailure('async\n(a, b) => {}', 'Unexpected token "=>"');


### PR DESCRIPTION
Fixes #411.