### PR TITLE
Allow `await` as identifier in parameter lists of methods inside async functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "ECMAScript parser that produces a Shift format AST",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-parser-js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -2339,11 +2339,11 @@ export class GenericParser extends Tokenizer {
           let previousAwaitLocation = this.firstAwaitLocation;
           this.allowYieldExpression = false;
           this.allowAwaitExpression = false;
-          this.previousAwaitLocation = null;
+          this.firstAwaitLocation = null;
           let body = this.parseFunctionBody();
           this.allowYieldExpression = previousYield;
           this.allowAwaitExpression = previousAwait;
-          this.previousAwaitLocation = previousAwaitLocation;
+          this.firstAwaitLocation = previousAwaitLocation;
           return {
             methodOrKey: this.finishNode(new AST.Getter({ name, body }), startState),
             kind: 'method',
@@ -2356,13 +2356,13 @@ export class GenericParser extends Tokenizer {
           let previousAwaitLocation = this.firstAwaitLocation;
           this.allowYieldExpression = false;
           this.allowAwaitExpression = false;
-          this.previousAwaitLocation = null;
+          this.firstAwaitLocation = null;
           let param = this.parseBindingElement();
           this.expect(TokenType.RPAREN);
           let body = this.parseFunctionBody();
           this.allowYieldExpression = previousYield;
           this.allowAwaitExpression = previousAwait;
-          this.previousAwaitLocation = previousAwaitLocation;
+          this.firstAwaitLocation = previousAwaitLocation;
           return {
             methodOrKey: this.finishNode(new AST.Setter({ name, param, body }), startState),
             kind: 'method',
@@ -2398,7 +2398,7 @@ export class GenericParser extends Tokenizer {
       let body = this.parseFunctionBody();
       this.allowYieldExpression = previousYield;
       this.allowAwaitExpression = previousAwait;
-      this.previousAwaitLocation = previousAwaitLocation;
+      this.firstAwaitLocation = previousAwaitLocation;
 
       return {
         methodOrKey: this.finishNode(new AST.Method({ isAsync, isGenerator, name, params, body }), startState),

--- a/test/miscellaneous/async-await.js
+++ b/test/miscellaneous/async-await.js
@@ -200,6 +200,53 @@ suite('async', () => {
       }
     );
 
+    testParse('async (a = { b(await){} }) => {}', expr,
+      {
+        type: 'ArrowExpression',
+        isAsync: true,
+        params: {
+          type: 'FormalParameters',
+          items: [
+            {
+              type: 'BindingWithDefault',
+              binding: { type: 'BindingIdentifier', name: 'a' },
+              init: {
+                type: 'ObjectExpression',
+                properties: [
+                  {
+                    type: 'Method',
+                    isAsync: false,
+                    isGenerator: false,
+                    name: {
+                      type: 'StaticPropertyName',
+                      value: 'b',
+                    },
+                    params: {
+                      type: 'FormalParameters',
+                      items: [
+                        {
+                          type: 'BindingIdentifier',
+                          name: 'await',
+                        },
+                      ],
+                      rest: null,
+                    },
+                    body: {
+                      type: 'FunctionBody',
+                      directives: [],
+                      statements: [],
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+          rest: null,
+        },
+        body: { type: 'FunctionBody', directives: [], statements: [] },
+      }
+    );
+
     testParseFailure('let b = async () => []; for (a in await b());', 'Unexpected identifier');
     testParse('async () => { let b = async () => []; for (a in await b()); }', expr,
       {


### PR DESCRIPTION
Fixes https://github.com/shapesecurity/shift-parser-js/issues/431.

This was just a typo.