### PR TITLE
fix destructuring rest properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shift-parser",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "ECMAScript parser that produces a Shift format AST",
   "author": "Shape Security",
   "homepage": "https://github.com/shapesecurity/shift-parser-js",

--- a/src/parser.js
+++ b/src/parser.js
@@ -2180,13 +2180,13 @@ export class GenericParser extends Tokenizer {
   parseSpreadPropertyDefinition() {
     let startState = this.startNode();
     this.expect(TokenType.ELLIPSIS);
-    let expressionOrAssignmentTarget = this.parseAssignmentExpressionOrTarget();
-    if (!isValidSimpleAssignmentTarget(expressionOrAssignmentTarget)) {
+    let expression = this.parseAssignmentExpression();
+    if (!isValidSimpleAssignmentTarget(expression)) {
       this.isBindingElement = this.isAssignmentTarget = false;
-    } else if (expressionOrAssignmentTarget.type !== 'IdentifierExpression') {
+    } else if (expression.type !== 'IdentifierExpression') {
       this.isBindingElement = false;
     }
-    return this.finishNode(new AST.SpreadProperty({ expression: expressionOrAssignmentTarget }), startState);
+    return this.finishNode(new AST.SpreadProperty({ expression }), startState);
   }
 
   parsePropertyDefinition() {

--- a/test/destructuring/assignment/array-binding.js
+++ b/test/destructuring/assignment/array-binding.js
@@ -21,8 +21,6 @@ let testParseFailure = require('../../assertions').testParseFailure;
 suite('Parser', () => {
   suite('array binding', () => {
     suite('assignment', () => {
-
-
       testParse('[a = 0, ...{b = 0}] = 0', expr, {
         type: 'AssignmentExpression',
         binding: {

--- a/test/destructuring/assignment/object-binding.js
+++ b/test/destructuring/assignment/object-binding.js
@@ -21,7 +21,24 @@ let testParseFailure = require('../../assertions').testParseFailure;
 suite('Parser', () => {
   suite('object binding', () => {
     suite('assignment', () => {
-
+      testParse('({a = 0, ...b} = 0);', expr, {
+        type: 'AssignmentExpression',
+        binding: {
+          type: 'ObjectAssignmentTarget',
+          properties: [
+            {
+              type: 'AssignmentTargetPropertyIdentifier',
+              binding: { type: 'AssignmentTargetIdentifier', name: 'a' },
+              init: { type: 'LiteralNumericExpression', value: 0 },
+            },
+          ],
+          rest: {
+            type: 'AssignmentTargetIdentifier',
+            name: 'b',
+          },
+        },
+        expression: { type: 'LiteralNumericExpression', value: 0 },
+      });
 
       testParseFailure('({a = 0});', 'Illegal property initializer');
       testParseFailure('({a} += 0);', 'Invalid left-hand side in assignment');

--- a/test/destructuring/binding-pattern/object-binding.js
+++ b/test/destructuring/binding-pattern/object-binding.js
@@ -22,13 +22,43 @@ let testParseFailure = require('../../assertions').testParseFailure;
 suite('Parser', () => {
   suite('object binding', () => {
     suite('variable declarator', () => {
-
+      testParse('var {a = 0, ...b} = 0;', p => stmt(p).declaration.declarators, [{
+        type: 'VariableDeclarator',
+        binding: {
+          type: 'ObjectBinding',
+          properties: [
+            {
+              type: 'BindingPropertyIdentifier',
+              binding: { type: 'BindingIdentifier', name: 'a' },
+              init: { type: 'LiteralNumericExpression', value: 0 },
+            },
+          ],
+          rest: {
+            type: 'BindingIdentifier',
+            name: 'b',
+          },
+        },
+        init: { type: 'LiteralNumericExpression', value: 0 },
+      }]);
 
       testParseFailure('var {a: b.c} = 0;', 'Unexpected token "."');
     });
 
     suite('formal parameter', () => {
-
+      testParse('async ({a = 0, ...b}) => 0;', p => expr(p).params.items, [{
+        type: 'ObjectBinding',
+        properties: [
+          {
+            type: 'BindingPropertyIdentifier',
+            binding: { type: 'BindingIdentifier', name: 'a' },
+            init: { type: 'LiteralNumericExpression', value: 0 },
+          },
+        ],
+        rest: {
+          type: 'BindingIdentifier',
+          name: 'b',
+        },
+      }]);
 
       // other passing cases are tested in other function test cases.
       testParseFailure('({e: a.b}) => 0', 'Illegal arrow function parameter list');
@@ -39,14 +69,10 @@ suite('Parser', () => {
       testParseFailure('({a({e: a.b}){}})', 'Unexpected token "."');
       testParseFailure('({*a({e: a.b}){}})', 'Unexpected token "."');
       testParseFailure('({set a({e: a.b}){}})', 'Unexpected token "."');
-
     });
 
     suite('catch clause', () => {
-
-
       testParseFailure('try {} catch ({e: x.a}) {}', 'Unexpected token "."');
     });
-
   });
 });


### PR DESCRIPTION
Fixes https://github.com/shapesecurity/shift-parser-js/issues/423 and https://github.com/shapesecurity/shift-parser-js/issues/425.

(The first commit. The second commit is just a simplification which doesn't change behavior.)